### PR TITLE
Fix formatting issue on "encoding" docs page.

### DIFF
--- a/content/programming-guides/encoding.md
+++ b/content/programming-guides/encoding.md
@@ -184,8 +184,8 @@ This is the *two's complement* of 2, defined in unsigned arithmetic as `~0 - 2 +
 understand why this produces so many ones.
 
 On the other hand, `sintN` uses the "ZigZag" encoding instead of two's
-complement to encode negative integers. Positive integers `n` are encoded as `2
-* n` (the even numbers), while negative integers `-n` are encoded as `2 * n + 1`
+complement to encode negative integers. Positive integers `n` are encoded as 
+`2 * n` (the even numbers), while negative integers `-n` are encoded as `2 * n + 1`
 (the odd numbers). The encoding thus "zig-zags" between positive and negative
 numbers. For example:
 


### PR DESCRIPTION
Currently, this paragraph renders weirdly:

> On the other hand, `sintN` uses the "ZigZag" encoding instead of two's
> complement to encode negative integers. Positive integers `n` are encoded as `2
> * n` (the even numbers), while negative integers `-n` are encoded as `2 * n + 1`

This PR fixes the odd formatting.