### PR TITLE
Issue 50 - Add documentation for PHP namespace options

### DIFF
--- a/content/reference/php/php-generated.md
+++ b/content/reference/php/php-generated.md
@@ -52,8 +52,8 @@ directory `build/gen/Foo/Bar` if necessary, but it will *not* create `build` or
 
 ## Packages {#package}
 
-The package name defined in the `.proto` file is used to generate a module
-structure for the generated PHP classes. Given a file like:
+The package name defined in the `.proto` file is used by default to generate
+a module structure for the generated PHP classes. Given a file like:
 
 ```proto
 package foo.bar;
@@ -63,6 +63,34 @@ message MyMessage {}
 
 The protocol compiler generates an output class with the name
 `Foo\Bar\MyMessage`.
+
+### Namespace options
+
+The compiler supports additional options to define the PHP and metadata
+namespace. When defined these will be used to generate the module structure
+and the namespace. Given options like:
+
+```proto
+package foo.bar;
+
+option php_namespace = "baz\\qux";
+
+option php_metadata_namespace = "Foo";
+
+message MyMessage {}
+```
+
+The protocol compiler generates an output class with the name
+`baz\qux\MyMessage`.
+The class will have the namespace
+`namespace baz\qux;`.
+
+The protocol compiler generates a metadata class with the name
+`Foo\Metadata`.
+The class will have the namespace
+`namespace Foo;`.
+
+_The options are also generated case-sensitive, by default the package is converted to pascal case._
 
 ## Messages {#message}
 


### PR DESCRIPTION
This pull request directly relates to https://github.com/protocolbuffers/protocolbuffers.github.io/issues/50

This expands the documentation for PHP Code Generation specifically documenting functionality added in the following two pull requests to `protocolbuffers/protobuf`.

* https://github.com/protocolbuffers/protobuf/pull/3162
* https://github.com/protocolbuffers/protobuf/pull/4609

For testing and validating the documentation the following `.proto` files was used

`MyMessage.proto`
```

syntax = "proto3";

package foo.bar;

option php_namespace = "baz\\qux";

option php_metadata_namespace = "Foo";

message MyMessage {}

```

and the following compiler command

`protoc --php_out=output MyMessage.proto`