### PR TITLE
protobuf/java: update oneof documentation

### DIFF
--- a/content/reference/java/java-generated.md
+++ b/content/reference/java/java-generated.md
@@ -549,7 +549,7 @@ oneof example_name {
 The compiler will generate the following accessor methods in both the message
 class and its builder:
 
--   `boolean hasFoo()` (proto2 only): Returns `true` if the oneof case is `FOO`.
+-   `boolean hasFoo()`: Returns `true` if the oneof case is `FOO`.
 -   `int getFoo()`: Returns the current value of `example_name` if the oneof
     case is `FOO`. Otherwise, returns the default value of this field.
 


### PR DESCRIPTION
The documentation currently states that for oneof fields, the `hasXXX` method is only generated for proto2. However, testing locally I found that it's also generated for proto3. Given that oneof fields in proto2 and proto3 both have field presence, this does seem to make sense.

Steps to reproduce:
1. Create a file `test.proto` with the contents:
```
syntax = "proto3";

message Test {
  oneof example {
    string a = 1;
    string b = 2;
  }
}
```
2. Create java class Run:
```
protoc -I=. --java_out=. test.proto
```

3. Inspect the resulting java file to see the

```
public interface TestOrBuilder extends
    // @@protoc_insertion_point(interface_extends:Test)
    com.google.protobuf.MessageOrBuilder {

  /**
   * <code>string a = 1;</code>
   * @return Whether the a field is set.
   */
  boolean hasA();
```

This commit updates the docs to remove the reference to "proto2 only".