### PR TITLE
Update EnumValueOptions override reference

### DIFF
--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -1664,9 +1664,9 @@ options using extensions.
 The following example shows the syntax for adding these options:
 
 ```proto
-import "net/proto2/proto/descriptor.proto";
+import "google/protobufs/descriptor.proto";
 
-extend proto2.EnumValueOptions {
+extend google.protobufs.EnumValueOptions {
   optional string string_name = 123456789;
 }
 


### PR DESCRIPTION
The `net/proto2/proto/descriptor.proto` path no longer matches what users can find in the https://github.com/protocolbuffers/protobuf repo.