### PR TITLE
Fix typo in "Enum Value Options"

### DIFF
--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -1670,9 +1670,9 @@ options using extensions.
 The following example shows the syntax for adding these options:
 
 ```proto
-import "google/protobufs/descriptor.proto";
+import "google/protobuf/descriptor.proto";
 
-extend google.protobufs.EnumValueOptions {
+extend google.protobuf.EnumValueOptions {
   optional string string_name = 123456789;
 }
 


### PR DESCRIPTION
`google.protobufs` does not exist, should be `google.protobuf` - note no `s` in the end