### PR TITLE
Project import generated by Copybara.

### DIFF
--- a/content/getting-started/cpptutorial.md
+++ b/content/getting-started/cpptutorial.md
@@ -88,9 +88,10 @@ message Person {
   optional string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
   }
 
   message PhoneNumber {
@@ -123,7 +124,7 @@ even define message types nested inside other messages -- as you can see, the
 `PhoneNumber` type is defined inside `Person`. You can also define `enum` types
 if you want one of your fields to have one of a predefined list of values --
 here you want to specify that a phone number can be one of the following phone
-types: `MOBILE`, `HOME`, or `WORK`.
+types: `PHONE_TYPE_MOBILE`, `PHONE_TYPE_HOME`, or `PHONE_TYPE_WORK`.
 
 The " = 1", " = 2" markers on each element identify the unique field number that
 field uses in the binary encoding. Field numbers 1-15 require one less byte to

--- a/content/getting-started/csharptutorial.md
+++ b/content/getting-started/csharptutorial.md
@@ -120,9 +120,10 @@ message Person {
   string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
   }
 
   message PhoneNumber {
@@ -146,7 +147,8 @@ while the `AddressBook` message contains `Person` messages. You can even define
 message types nested inside other messages -- as you can see, the `PhoneNumber`
 type is defined inside `Person`. You can also define `enum` types if you want
 one of your fields to have one of a predefined list of values -- here you want
-to specify that a phone number can be one of `MOBILE`, `HOME`, or `WORK`.
+to specify that a phone number can be one of `PHONE_TYPE_MOBILE`,
+`PHONE_TYPE_HOME`, or `PHONE_TYPE_WORK`.
 
 The " = 1", " = 2" markers on each element identify the unique "tag" that field
 uses in the binary encoding. Tag numbers 1-15 require one less byte to encode

--- a/content/getting-started/darttutorial.md
+++ b/content/getting-started/darttutorial.md
@@ -103,9 +103,10 @@ message Person {
   string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
   }
 
   message PhoneNumber {
@@ -129,7 +130,8 @@ while the `AddressBook` message contains `Person` messages. You can even define
 message types nested inside other messages -- as you can see, the `PhoneNumber`
 type is defined inside `Person`. You can also define `enum` types if you want
 one of your fields to have one of a predefined list of values -- here you want
-to specify that a phone number can be one of `MOBILE`, `HOME`, or `WORK`.
+to specify that a phone number can be one of `PHONE_TYPE_MOBILE`,
+`PHONE_TYPE_HOME`, or `PHONE_TYPE_WORK`.
 
 The " = 1", " = 2" markers on each element identify the unique "tag" that field
 uses in the binary encoding. Tag numbers 1-15 require one less byte to encode

--- a/content/getting-started/gotutorial.md
+++ b/content/getting-started/gotutorial.md
@@ -114,9 +114,10 @@ message Person {
   string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
   }
 
   message PhoneNumber {
@@ -140,7 +141,8 @@ while the `AddressBook` message contains `Person` messages. You can even define
 message types nested inside other messages -- as you can see, the `PhoneNumber`
 type is defined inside `Person`. You can also define `enum` types if you want
 one of your fields to have one of a predefined list of values -- here you want
-to specify that a phone number can be one of `MOBILE`, `HOME`, or `WORK`.
+to specify that a phone number can be one of `PHONE_TYPE_MOBILE`,
+`PHONE_TYPE_HOME`, or `PHONE_TYPE_WORK`.
 
 The " = 1", " = 2" markers on each element identify the unique "tag" that field
 uses in the binary encoding. Tag numbers 1-15 require one less byte to encode

--- a/content/getting-started/javatutorial.md
+++ b/content/getting-started/javatutorial.md
@@ -92,9 +92,10 @@ message Person {
   optional string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
   }
 
   message PhoneNumber {
@@ -145,7 +146,7 @@ even define message types nested inside other messages -- as you can see, the
 `PhoneNumber` type is defined inside `Person`. You can also define `enum` types
 if you want one of your fields to have one of a predefined list of values --
 here you want to specify that a phone number can be one of the following phone
-types: `MOBILE`, `HOME`, or `WORK`.
+types: `PHONE_TYPE_MOBILE`, `PHONE_TYPE_HOME`, or `PHONE_TYPE_WORK`.
 
 The " = 1", " = 2" markers on each element identify the unique "tag" that field
 uses in the binary encoding. Tag numbers 1-15 require one less byte to encode
@@ -313,9 +314,10 @@ The generated code includes a `PhoneType` Java 5 enum, nested within `Person`:
 
 ```java
 public static enum PhoneType {
-  MOBILE(0, 0),
-  HOME(1, 1),
-  WORK(2, 2),
+  PHONE_TYPE_UNSPECIFIED(0, 0),
+  PHONE_TYPE_MOBILE(1, 1),
+  PHONE_TYPE_HOME(2, 2),
+  PHONE_TYPE_WORK(3, 3),
   ;
   ...
 }

--- a/content/getting-started/kotlintutorial.md
+++ b/content/getting-started/kotlintutorial.md
@@ -106,9 +106,10 @@ message Person {
   string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
   }
 
   message PhoneNumber {
@@ -132,7 +133,8 @@ while the `AddressBook` message contains `Person` messages. You can even define
 message types nested inside other messages -- as you can see, the `PhoneNumber`
 type is defined inside `Person`. You can also define `enum` types if you want
 one of your fields to have one of a predefined list of values -- here you want
-to specify that a phone number can be one of `MOBILE`, `HOME`, or `WORK`.
+to specify that a phone number can be one of `PHONE_TYPE_MOBILE`,
+`PHONE_TYPE_HOME`, or `PHONE_TYPE_WORK`.
 
 The " = 1", " = 2" markers on each element identify the unique "tag" that field
 uses in the binary encoding. Tag numbers 1-15 require one less byte to encode

--- a/content/getting-started/pythontutorial.md
+++ b/content/getting-started/pythontutorial.md
@@ -86,9 +86,10 @@ message Person {
   optional string email = 3;
 
   enum PhoneType {
-    MOBILE = 0;
-    HOME = 1;
-    WORK = 2;
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
   }
 
   message PhoneNumber {

--- a/content/news/2023-06-29.md
+++ b/content/news/2023-06-29.md
@@ -135,7 +135,7 @@ message Player {
     HANDED_AMBIDEXTROUS = 3,
   }
 
-  Handed handed = 4 [features.field_presence = IMPLICIT];
+  Handed handed = 4;
 }
 ```
 

--- a/content/news/2023-07-06.md
+++ b/content/news/2023-07-06.md
@@ -1,0 +1,32 @@
++++
+title = "Changes Announced on July 6, 2023"
+weight = 21
+linkTitle = "July 6, 2023"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers on July 6, 2023."
+type = "docs"
++++
+
+## Dropping PHP 7.x Support
+
+As per our official
+[PHP support policy](https://cloud.google.com/php/getting-started/supported-php-versions),
+we will be dropping support for PHP 7.4 and lower. This means the minimum
+supported PHP version is 8.0.
+
+If you are running an older version of PHP, you can install a previous release
+of the protobuf PHP extension by running `pecl install protobuf-3.23.3`.
+
+## Dropping Ruby 2.6 Support
+
+As per our official
+[Ruby support policy](https://cloud.google.com/ruby/getting-started/supported-ruby-versions),
+we will be dropping support for Ruby 2.6 and lower. This means the minimum
+supported Ruby version is 2.7.
+
+## Dropping Python 3.7 Support
+
+As per our official
+[Python support policy](https://cloud.google.com/python/docs/supported-python-versions),
+we will be dropping support for Python 3.7 and lower. This means the minimum
+supported Python version is 3.8.

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -8,6 +8,8 @@ type = "docs"
 News topics provide information about past events and changes with Protocol
 Buffers, and plans for upcoming changes.
 
+*   [July 6, 2023](/news/2023-07-06) - Dropping support
+    for older versions of PHP, Ruby, and Python
 *   [June 29, 2023](/news/2023-06-29) - Protobuf Editions
     announcement
 *   [April 28, 2023](/news/2023-04-28) - Null no longer

--- a/content/programming-guides/proto2.md
+++ b/content/programming-guides/proto2.md
@@ -1670,7 +1670,7 @@ extend google.protobuf.EnumValueOptions {
 }
 
 enum Data {
-  DATA_UNKNOWN = 0;
+  DATA_UNSPECIFIED = 0;
   DATA_SEARCH = 1 [deprecated = true];
   DATA_DISPLAY = 2 [
     (string_name) = "display_value"

--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -1670,9 +1670,9 @@ options using extensions.
 The following example shows the syntax for adding these options:
 
 ```proto
-import "google/protobufs/descriptor.proto";
+import "google/protobuf/descriptor.proto";
 
-extend google.protobufs.EnumValueOptions {
+extend google.protobuf.EnumValueOptions {
   optional string string_name = 123456789;
 }
 

--- a/content/reference/cpp/cpp-generated.md
+++ b/content/reference/cpp/cpp-generated.md
@@ -361,8 +361,9 @@ Given the enum type:
 
 ```proto
 enum Bar {
-  BAR_VALUE = 0;
-  OTHER_VALUE = 1;
+  BAR_UNSPECIFIED = 0;
+  BAR_VALUE = 1;
+  BAR_OTHER_VALUE = 2;
 }
 ```
 
@@ -391,8 +392,9 @@ Given the enum type:
 
 ```proto
 enum Bar {
-  BAR_VALUE = 0;
-  OTHER_VALUE = 1;
+  BAR_UNSPECIFIED = 0;
+  BAR_VALUE = 1;
+  BAR_OTHER_VALUE = 2;
 }
 ```
 
@@ -538,8 +540,9 @@ Given the enum type:
 
 ```proto
 enum Bar {
-  BAR_VALUE = 0;
-  OTHER_VALUE = 1;
+  BAR_UNSPECIFIED = 0;
+  BAR_VALUE = 1;
+  BAR_OTHER_VALUE = 2;
 }
 ```
 
@@ -716,8 +719,9 @@ Given the enum type:
 
 ```proto
 enum Bar {
-  BAR_VALUE = 0;
-  OTHER_VALUE = 1;
+  BAR_UNSPECIFIED = 0;
+  BAR_VALUE = 1;
+  BAR_OTHER_VALUE = 2;
 }
 ```
 

--- a/content/reference/csharp/csharp-generated.md
+++ b/content/reference/csharp/csharp-generated.md
@@ -353,7 +353,8 @@ Given an enumeration definition like:
 
 ```proto
 enum Color {
-  COLOR_RED = 0;
+  COLOR_UNSPECIFIED = 0;
+  COLOR_RED = 1;
   COLOR_GREEN = 5;
   COLOR_BLUE = 1234;
 }
@@ -372,7 +373,8 @@ The `Color` proto enum above would therefore become the following C\# code:
 ```csharp
 enum Color
 {
-  Red = 0,
+  Unspecified = 0,
+  Red = 1,
   Green = 5,
   Blue = 1234
 }

--- a/content/reference/dart/dart-generated.md
+++ b/content/reference/dart/dart-generated.md
@@ -337,16 +337,17 @@ Given an enum definition like:
 
 ```proto
 enum Color {
-  RED = 0;
-  GREEN = 1;
-  BLUE = 2;
+  COLOR_UNSPECIFIED = 0;
+  COLOR_RED = 1;
+  COLOR_GREEN = 2;
+  COLOR_BLUE = 3;
 }
 ```
 
 The protocol buffer compiler will generate a class called `Color`, which extends
 the `ProtobufEnum` class. The class will include a `static const Color` for each
 of the three values defined as well as a `static const List<Color>` containing
-all the three values. It will also include the following method:
+all the three non-unspecified values. It will also include the following method:
 
 -   `static Color? valueOf(int value)`: Returns the `Color` corresponding to the
     given numeric value.
@@ -378,9 +379,10 @@ definition like:
 ```proto
 message Bar {
   enum Color {
-    RED = 0;
-    GREEN = 1;
-    BLUE = 2;
+    COLOR_UNSPECIFIED = 0;
+    COLOR_RED = 1;
+    COLOR_GREEN = 2;
+    COLOR_BLUE = 3;
   }
 }
 ```

--- a/content/reference/python/python-generated.md
+++ b/content/reference/python/python-generated.md
@@ -114,7 +114,7 @@ module to work with protocol messages in text format: for example, the `Merge()`
 method lets you merge an ASCII representation of a message into an existing
 message.
 
-### Nested Types
+### Nested Types {#nested-types}
 
 A message can be declared inside another message. For example:
 
@@ -137,7 +137,7 @@ message methods, as they subclass both
 [`google.protobuf.Message`](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html#google.protobuf.message.Message)
 and a WKT class.
 
-### Any
+### Any {#any}
 
 For Any messages, you can call `Pack()` to pack a specified message into the
 current Any message, or `Unpack()` to unpack the current Any message into a
@@ -159,7 +159,10 @@ given protocol buffer type. For example:
 assert any_message.Is(message.DESCRIPTOR)
 ```
 
-### Timestamp
+Use the `TypeName()` method to retrieve the protobuf type name of an inner
+message.
+
+### Timestamp {#timestamp}
 
 Timestamp messages can be converted to/from RFC 3339 date string format (JSON
 string) using the `ToJsonString()`/`FromJsonString()` methods. For example:
@@ -190,7 +193,7 @@ timestamp_message.FromDatetime(dt)
 self.assertEqual(dt, timestamp_message.ToDatetime())
 ```
 
-### Duration
+### Duration {#duration}
 
 Duration messages have the same methods as Timestamp to convert between JSON
 string and other time units. To convert between timedelta and Duration, you can
@@ -203,23 +206,24 @@ assert td.seconds == 1
 assert td.microseconds == 999999
 ```
 
-### FieldMask
+### FieldMask {#fieldmask}
 
 FieldMask messages can be converted to/from JSON string using the
 `ToJsonString()`/`FromJsonString()` methods. In addition, a FieldMask message
 has the following methods:
 
--   `IsValidForDescriptor`: Checks whether the FieldMask is valid for Message
-    Descriptor.
--   `AllFieldsFromDescriptor`: Gets all direct fields of Message Descriptor to
-    FieldMask.
--   `CanonicalFormFromMask`: Converts a FieldMask to the canonical form.
--   `Union`: Merges two FieldMasks into this FieldMask.
--   `Intersect`: Intersects two FieldMasks into this FieldMask.
--   `MergeMessage`: Merges fields specified in FieldMask from source to
-    destination.
+-   `IsValidForDescriptor(message_descriptor)`: Checks whether the FieldMask is
+    valid for Message Descriptor.
+-   `AllFieldsFromDescriptor(message_descriptor)`: Gets all direct fields of
+    Message Descriptor to FieldMask.
+-   `CanonicalFormFromMask(mask)`: Converts a FieldMask to the canonical form.
+-   `Union(mask1, mask2)`: Merges two FieldMasks into this FieldMask.
+-   `Intersect(mask1, mask2)`: Intersects two FieldMasks into this FieldMask.
+-   `MergeMessage(source, destination, replace_message_field=False,
+    replace_repeated_field=False)`: Merges fields specified in FieldMask from
+    source to destination.
 
-### Struct
+### Struct {#struct}
 
 Struct messages let you get and set the items directly. For example:
 
@@ -237,7 +241,7 @@ struct.get_or_create_struct("key4")["subkey"] = 11.0
 struct.get_or_create_list("key5")
 ```
 
-### ListValue
+### ListValue {#listvalue}
 
 A ListValue message acts like a Python sequence that lets you do the following:
 
@@ -260,7 +264,7 @@ list_value.add_struct()["key"] = 1
 list_value.add_list().extend([1, "two", True])
 ```
 
-## Fields
+## Fields {#fields}
 
 For each field in a message type, the corresponding class has a property with
 the same name as the field. How you can manipulate the property depends on its
@@ -276,7 +280,7 @@ If the field's name is a Python keyword, then its property will only be
 accessible via `getattr()` and `setattr()`, as described in the
 [*Names which conflict with Python keywords*](#keyword-conflicts) section.
 
-### Singular Fields (proto2)
+### Singular Fields (proto2) {#singular-fields-proto2}
 
 If you have a singular (optional or required) field `foo` of any non-message
 type, you can manipulate the field `foo` as if it were a regular field. For
@@ -303,7 +307,7 @@ message.ClearField("foo")
 assert not message.HasField("foo")
 ```
 
-### Singular Fields (proto3)
+### Singular Fields (proto3) {#singular-fields-proto3}
 
 If you have a singular field `foo` of any non-message type, you can manipulate
 the field `foo` as if it were a regular field. For example, if `foo`'s type is
@@ -327,19 +331,13 @@ message.foo = 123
 message.ClearField("foo")
 ```
 
-{{% alert title="Note" color="note" %}}
-Unlike in proto2, you cannot call `HasField()` for a singular non-message field
-in proto3, and the library will throw an exception if you try to do this.
-{{% /alert %}}
-
 ### Singular Message Fields {#embedded_message}
 
 Message types work slightly differently. You cannot assign a value to an
 embedded message field. Instead, assigning a value to any field within the child
-message implies setting the message field in the parent. In proto3, you can also
-use the parent message's `HasField()` method to check if a message type field
-value has been set, which you can't do with other types of proto3 singular
-field.
+message implies setting the message field in the parent. You can also use the
+parent message's `HasField()` method to check if a message type field value has
+been set.
 
 So, for example, let's say you have the following `.proto` definition:
 
@@ -401,7 +399,7 @@ foo.bar.SetInParent()  # Set Foo.bar to a default Bar message
 assert foo.HasField("bar")
 ```
 
-### Repeated Fields
+### Repeated Fields {#repeated-fields}
 
 Repeated fields are represented as an object that acts like a Python sequence.
 As with embedded messages, you cannot assign the field directly, but you can
@@ -439,7 +437,11 @@ The `ClearField()` method of the
 [`Message`](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html#google.protobuf.message.Message)
 interface works in addition to using Python `del`.
 
-### Repeated Message Fields
+When using the index to retrieve a value, you can use negative numbers, such as
+using `-1` to retrieve the last element in the list. If your index goes out of
+bounds, you'll get an `IndexError: list index out of range`.
+
+### Repeated Message Fields {#repeated-message-fields}
 
 Repeated message fields work similar to repeated scalar fields. However, the
 corresponding Python object also has an `add()` method that creates a new
@@ -531,7 +533,7 @@ foo.bars[0] = Bar(i=15)  # Raises an exception
 foo.bars[:] = [Bar(i=15), Bar(i=17)]  # Also raises an exception
 ```
 
-### Groups (proto2)
+### Groups (proto2) {#groups-proto2}
 
 **Note that groups are deprecated and should not be used when creating new
 message types -- use nested message types instead.**
@@ -549,13 +551,13 @@ equivalent:
 // Version 1: Using groups
 message SearchResponse {
   repeated group SearchResult = 1 {
-    required string url = 1;
+    optional string url = 1;
   }
 }
 // Version 2: Not using groups
 message SearchResponse {
   message SearchResult {
-    required string url = 1;
+    optional string url = 1;
   }
   repeated SearchResult searchresult = 1;
 }
@@ -576,7 +578,7 @@ assert resp.searchresult[0].url == "https://blog.google"
 assert resp.searchresult[0] == SearchResponse.SearchResult(url="https://blog.google")
 ```
 
-### Map Fields
+### Map Fields {#map-fields}
 
 Given this message definition:
 
@@ -786,7 +788,7 @@ enum SomeEnum {
 
 In the above example, `myproto_pb2.SomeEnum.Name(5)` returns `"VALUE_B"`.
 
-## Oneof
+## Oneof {#oneof}
 
 Given a message with a oneof:
 
@@ -955,7 +957,7 @@ of the same names. Plugins are new in version 2.3.0 (January 2010).
 The remainder of this section describes what the protocol buffer compiler
 generates when abstract services are enabled.
 
-### Interface
+### Interface {#interface}
 
 Given a service definition:
 
@@ -994,7 +996,7 @@ automatically generates implementations of the methods of `Service` as follows:
 -   `GetRequestClass` and `GetResponseClass`: Returns the class of the request
     or response of the correct type for the given method.
 
-### Stub
+### Stub {#stub}
 
 The protocol buffer compiler also generates a \"stub\" implementation of every
 service interface, which is used by clients wishing to send requests to servers

--- a/content/support/version-support.md
+++ b/content/support/version-support.md
@@ -688,8 +688,8 @@ The PHP 3.23.x runtime was first released in 2023 Q2.
 
 ## Python {#python}
 
-The Python 3.20.x runtime was first released in 2022 Q1 and has support until
-2023 Q2. The Python 4.23.x runtime was first released in 2023 Q2.
+The Python 4.23.x runtime was first released in 2023 Q2. The Python 3.x runtime
+went out of support on July 1, 2023.
 
 <table>
   <tr>


### PR DESCRIPTION
PiperOrigin-RevId: 546298303
Change-Id: Icf2a0e62c5ac9a559311069615a245fd31069858

* Applies best practices/style guide to example enums
* Releases a new topic in protobuf.dev/news
* Corrects an example in the 2023-06-29 news topic
* Fixes a path in the proto3.md topic
* Added anchors to the Python Generated Code topic headings
* Added content about `TypeName()` to the Python Generated Code topic
* Fleshed out the method signatures for FieldMask-related methods in the Python Generated Code topic
* In the Python Generated Code topic, clarified that `HasField()` works for both proto2 and proto3
* Added a paragraph about using negative index numbers to traverse a repeated field in reverse order to the Python Generated Code topic
* Replaced `required` with `optional` in examples in the Python Generated Code topic
* Updated the Version Support topic to reflect that Python 3.x is no longer supported.
