### PR TITLE
Update "Download and install" URL in index.md

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -93,7 +93,7 @@ Dart, Go, Ruby, PHP, and C#, with more languages to come.
 <ol>
 
   <li>
-    <a href="https://github.com/protocolbuffers/protobuf#protocol-compiler-installation">Download
+    <a href="https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation">Download
     and install</a> the protocol buffer compiler.
   </li>
 


### PR DESCRIPTION
Since this commit https://github.com/protocolbuffers/protobuf/commit/3c3dfe0efa859563e1fdbe51badd0ebf74760ff9 in protobuf repository, the URL has changed.