### PR TITLE
This change includes the following modifications:

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -93,7 +93,7 @@ Dart, Go, Ruby, PHP, and C#, with more languages to come.
 <ol>
 
   <li>
-    <a href="https://github.com/protocolbuffers/protobuf#protocol-compiler-installation">Download
+    <a href="https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation">Download
     and install</a> the protocol buffer compiler.
   </li>
 

--- a/content/editions/overview.md
+++ b/content/editions/overview.md
@@ -224,7 +224,7 @@ message Person {
   string name = 1;
   int32 id = 2 [features.presence = IMPLICIT];
 
-  enum Pay_Type
+  enum Pay_Type {
     PAY_TYPE_UNSPECIFIED = 1,
     PAY_TYPE_SALARY = 2,
     PAY_TYPE_HOURLY = 3

--- a/content/getting-started/cpptutorial.md
+++ b/content/getting-started/cpptutorial.md
@@ -276,9 +276,9 @@ any particular field definition, see the
 
 The generated code includes a `PhoneType` enum that corresponds to your `.proto`
 enum. You can refer to this type as `Person::PhoneType` and its values as
-`Person::MOBILE`, `Person::HOME`, and `Person::WORK` (the implementation details
-are a little more complicated, but you don't need to understand them to use the
-enum).
+`Person::PHONE_TYPE_MOBILE`, `Person::PHONE_TYPE_HOME`, and
+`Person::PHONE_TYPE_WORK` (the implementation details are a little more
+complicated, but you don't need to understand them to use the enum).
 
 The compiler has also generated a nested class for you called
 `Person::PhoneNumber`. If you look at the code, you can see that the "real"
@@ -394,11 +394,11 @@ void PromptForAddress(tutorial::Person* person) {
     string type;
     getline(cin, type);
     if (type == "mobile") {
-      phone_number->set_type(tutorial::Person::MOBILE);
+      phone_number->set_type(tutorial::Person::PHONE_TYPE_MOBILE);
     } else if (type == "home") {
-      phone_number->set_type(tutorial::Person::HOME);
+      phone_number->set_type(tutorial::Person::PHONE_TYPE_HOME);
     } else if (type == "work") {
-      phone_number->set_type(tutorial::Person::WORK);
+      phone_number->set_type(tutorial::Person::PHONE_TYPE_WORK);
     } else {
       cout << "Unknown phone type.  Using default." << endl;
     }
@@ -494,13 +494,13 @@ void ListPeople(const tutorial::AddressBook& address_book) {
       const tutorial::Person::PhoneNumber& phone_number = person.phones(j);
 
       switch (phone_number.type()) {
-        case tutorial::Person::MOBILE:
+        case tutorial::Person::PHONE_TYPE_MOBILE:
           cout << "  Mobile phone #: ";
           break;
-        case tutorial::Person::HOME:
+        case tutorial::Person::PHONE_TYPE_HOME:
           cout << "  Home phone #: ";
           break;
-        case tutorial::Person::WORK:
+        case tutorial::Person::PHONE_TYPE_WORK:
           cout << "  Work phone #: ";
           break;
       }

--- a/content/news/2022-05-06.md
+++ b/content/news/2022-05-06.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes announced May 6, 2022"
-weight = 27
 linkTitle = "May 6, 2022"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on May 6, 2022."

--- a/content/news/2022-07-06.md
+++ b/content/news/2022-07-06.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes announced July 6, 2022"
-weight = 26
 linkTitle = "July 6, 2022"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on July 6, 2022."

--- a/content/news/2022-08-03.md
+++ b/content/news/2022-08-03.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes announced August 3, 2022"
-weight = 25
 linkTitle = "August 3, 2022"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on August 3, 2022."

--- a/content/news/2023-04-11.md
+++ b/content/news/2023-04-11.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes announced April 11, 2023"
-weight = 24
 linkTitle = "April 11, 2023"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on April 11, 2023."

--- a/content/news/2023-04-20.md
+++ b/content/news/2023-04-20.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes announced April 20, 2023"
-weight = 23
 linkTitle = "April 20, 2023"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on April 20, 2023."

--- a/content/news/2023-04-28.md
+++ b/content/news/2023-04-28.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes announced April 28, 2023"
-weight = 22
 linkTitle = "April 28, 2023"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on April 28, 2023."

--- a/content/news/2023-06-29.md
+++ b/content/news/2023-06-29.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes Announced on June 29, 2023"
-weight = 21
 linkTitle = "June 29, 2023"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on June 29, 2023."

--- a/content/news/2023-07-06.md
+++ b/content/news/2023-07-06.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes Announced on July 6, 2023"
-weight = 21
 linkTitle = "July 6, 2023"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on July 6, 2023."

--- a/content/news/2023-07-17.md
+++ b/content/news/2023-07-17.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes Announced on July 17, 2023"
-weight = 21
 linkTitle = "July 17, 2023"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on July 17, 2023."

--- a/content/news/2023-08-09.md
+++ b/content/news/2023-08-09.md
@@ -1,0 +1,38 @@
++++
+title = "Changes Announced on August 9, 2023"
+weight = 21
+linkTitle = "August 9, 2023"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers on August 9, 2023."
+type = "docs"
++++
+
+## .NET support policy
+
+The Protobuf team supports .NET in two ways:
+
+- Generation of C# code by protoc
+- The [Google.Protobuf NuGet package](https://www.nuget.org/packages/Google.Protobuf),
+  which provides runtime support for the generated code, as well as reflection
+  and other facilities
+
+The support policy for these has previously been unclear, particularly in terms
+of which .NET runtimes are supported. From August 2023 onwards, support will be
+provided in accordance with the [Google Open Source support policy for
+.NET](https://opensource.google/documentation/policies/dotnet-support). We
+expect this to mean that some old versions of .NET will be dropped from the
+`Google.Protobuf` package without taking a new major version.
+
+Protobuf is relatively unusual within Google projects supporting .NET in two
+respects: Firstly, as we support generating C# which we expect customers to
+compile, we need to consider language versions as well as runtime versions. The
+current policy does not cover this aspect of support, so we will publish a
+separate policy for this. Secondly, while Unity is not a first-class
+supported platform, we understand that Protobuf is commonly used on Unity, and
+we will intend to avoid breaking that usage as far as is reasonably possible.
+
+More details will be published when a new set of target platforms has been
+decided for `Google.Protobuf`. This will be at least one month ahead of the
+release in which it will take effect, in order to provide time for community
+feedback. For now, we recommend that users review the
+[support policy](https://opensource.google/documentation/policies/dotnet-support).

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -8,6 +8,8 @@ type = "docs"
 News topics provide information about past events and changes with Protocol
 Buffers, and plans for upcoming changes.
 
+*   [August 9, 2023](/news/2023-08-09) - Support policy
+    for .NET
 *   [July 17, 2023](/news/2023-07-17) - Dropping support
     for older versions of Bazel
 *   [July 6, 2023](/news/2023-07-06) - Dropping support

--- a/content/programming-guides/dos-donts.md
+++ b/content/programming-guides/dos-donts.md
@@ -236,6 +236,17 @@ A common practice is to generate your protos into a `proto` subpackage in your
 project that **only** contains those protos (that is, no hand-written source
 code).
 
+## Avoid Using Language Keywords for Field Names {#avoid-keywords}
+
+If the name of a message, field, enum, or enum value is a keyword in the
+language that reads from/writes to that field, then protobuf may change the
+field name, and may have different ways to access them than normal fields. For
+example, see
+[this warning about Python](/reference/python/python-generated#keyword-conflicts).
+
+You should also avoid using keywords in your file paths, as this can also cause
+problems.
+
 ## Appendix {#appendix}
 
 ### API Best Practices {#api-best-practices}

--- a/content/reference/go/faq.md
+++ b/content/reference/go/faq.md
@@ -113,7 +113,7 @@ global registry.
 
 Every protobuf declaration (for example, enums, enum values, or messages) has an
 absolute name, which is the concatenation of the
-[package name](/programming-guides/proto#packages) with
+[package name](/programming-guides/proto2#packages) with
 the relative name of the declaration in the `.proto` source file (for example,
 `my.proto.package.MyMessage.NestedMessage`). The protobuf language assumes that
 all declarations are universally unique.
@@ -152,9 +152,9 @@ Common ways that namespace conflicts occur:
     deliberately chosen to be universally unique (for example, prefixed with the
     name of a company).
 
-    *   Warning: Retroactively changing the package name on a `.proto` file can
-        potentially cause the use of extension fields or messages stored in
-        `google.protobuf.Any` to stop working properly.
+    *   **Warning:** Retroactively changing the package name on a `.proto` file
+        is not backwards compatible for types used as extension fields, stored
+        in `google.protobuf.Any`, or for gRPC Service definitions.
 
 Starting with v1.26.0 of the `google.golang.org/protobuf` module, a hard error
 will be reported when a Go program starts up that has multiple conflicting

--- a/content/reference/protobuf/textformat-spec.md
+++ b/content/reference/protobuf/textformat-spec.md
@@ -624,12 +624,15 @@ provided below.
 {{% alert title="Important" color="warning" %}}
 `.txtpb` is the canonical text format file extension and should be preferred to
 the alternatives. This suffix is preferred for its brevity and consistency with
-the official wire-format file extension `.binpb`. Some tools also recognize the
-legacy extensions `.textproto`, `.textpb` and `.pbtxt`. METADATA files are also
-a textproto files despite the lack of extension. All other extensions are
-**strongly** discouraged; in particular, extensions such as `.protoascii`
-wrongly imply that text format is ascii-only, and others like `.pb.txt` are not
-recognized by common tooling. {{% /alert %}}
+the official wire-format file extension `.binpb`. The legacy canonical extension
+`.textproto` still has widespread usage and tooling
+support. Some tooling also
+supports the legacy extensions `.textpb` and `.pbtxt`. All other extensions
+besides the above are **strongly** discouraged; in particular, extensions such
+as `.protoascii` wrongly imply that text format is ascii-only, and others like
+`.pb.txt` are not recognized by common tooling. METADATA files are special text
+format proto files that lack any extension.
+{{% /alert %}}
 
 ```textproto
 # This is an example of Protocol Buffer's text format.

--- a/content/support/version-support.md
+++ b/content/support/version-support.md
@@ -530,7 +530,7 @@ The Objective-C 3.23.x runtime was first released in 2023 Q2.
     <td title=23Q4></td>
   </tr>
   <tr>
-    <td class="gray">24.x</td>
+    <td class="gray">25.x</td>
     <td class="gray"></td>
     <td title=22Q1></td>
     <td title=22Q2></td>


### PR DESCRIPTION
* Fixes an anchor link in the home page

* Adds a missing open brace to the overview topic

* Corrects value names in the C++ tutorial

* Adds a news entry for support policy changes for .NET

* Updates news entries to remove the weight metadata values (since the individual news entries don’t appear in the table of contents, a weight is unnecessary)

* Adds the entry, “Avoid Using Language Keywords for Field Names,” to the Dos and Dont’s topic

* Updates the note about retroactively changing the package name in the Go FAQ topic

* Merges the two oneof topics in the Java Generated Code topic

* Adds heading anchors to the Java Generated Code topic

* Updates the wire-format file extension recommendation in the Text Format Spec topic

* Corrects a heading in one of the tables in the Version Support topic

PiperOrigin-RevId: 555091609
Change-Id: I87045266bd1721e70e53b3e4f9c0642b7e7b5f18