### PR TITLE
Fix default value for PhoneType in Python docs

### DIFF
--- a/content/getting-started/pythontutorial.md
+++ b/content/getting-started/pythontutorial.md
@@ -94,7 +94,7 @@ message Person {
 
   message PhoneNumber {
     optional string number = 1;
-    optional PhoneType type = 2 [default = HOME];
+    optional PhoneType type = 2 [default = PHONE_TYPE_HOME];
   }
 
   repeated PhoneNumber phones = 4;


### PR DESCRIPTION
Hi all, I was following the Python docs and stumbled on this error:
```
addressbook.proto:19:44: Enum type "tutorial.Person.PhoneType" has no value named "HOME".
```