### PR TITLE
This set of changes includes the following:

### DIFF
--- a/content/getting-started/darttutorial.md
+++ b/content/getting-started/darttutorial.md
@@ -251,13 +251,13 @@ Person promptForAddress() {
     String type = stdin.readLineSync();
     switch (type) {
       case 'mobile':
-        phoneNumber.type = Person_PhoneType.MOBILE;
+        phoneNumber.type = Person_PhoneType.PHONE_TYPE_MOBILE;
         break;
       case 'home':
-        phoneNumber.type = Person_PhoneType.HOME;
+        phoneNumber.type = Person_PhoneType.PHONE_TYPE_HOME;
         break;
       case 'work':
-        phoneNumber.type = Person_PhoneType.WORK;
+        phoneNumber.type = Person_PhoneType.PHONE_TYPE_WORK;
         break;
       default:
         print('Unknown phone type.  Using default.');
@@ -312,13 +312,13 @@ void printAddressBook(AddressBook addressBook) {
 
     for (Person_PhoneNumber phoneNumber in person.phones) {
       switch (phoneNumber.type) {
-        case Person_PhoneType.MOBILE:
+        case Person_PhoneType.PHONE_TYPE_MOBILE:
           print('   Mobile phone #: ');
           break;
-        case Person_PhoneType.HOME:
+        case Person_PhoneType.PHONE_TYPE_HOME:
           print('   Home phone #: ');
           break;
-        case Person_PhoneType.WORK:
+        case Person_PhoneType.PHONE_TYPE_WORK:
           print('   Work phone #: ');
           break;
         default:

--- a/content/getting-started/gotutorial.md
+++ b/content/getting-started/gotutorial.md
@@ -232,7 +232,7 @@ p := pb.Person{
     Name:  "John Doe",
     Email: "jdoe@example.com",
     Phones: []*pb.Person_PhoneNumber{
-        {Number: "555-4321", Type: pb.Person_HOME},
+        {Number: "555-4321", Type: pb.Person_PHONE_TYPE_HOME},
     },
 }
 ```

--- a/content/getting-started/javatutorial.md
+++ b/content/getting-started/javatutorial.md
@@ -100,7 +100,7 @@ message Person {
 
   message PhoneNumber {
     optional string number = 1;
-    optional PhoneType type = 2 [default = HOME];
+    optional PhoneType type = 2 [default = PHONE_TYPE_HOME];
   }
 
   repeated PhoneNumber phones = 4;
@@ -350,7 +350,7 @@ Person john =
     .addPhones(
       Person.PhoneNumber.newBuilder()
         .setNumber("555-4321")
-        .setType(Person.PhoneType.HOME))
+        .setType(Person.PhoneType.PHONE_TYPE_HOME))
     .build();
 ```
 
@@ -460,11 +460,11 @@ class AddPerson {
       stdout.print("Is this a mobile, home, or work phone? ");
       String type = stdin.readLine();
       if (type.equals("mobile")) {
-        phoneNumber.setType(Person.PhoneType.MOBILE);
+        phoneNumber.setType(Person.PhoneType.PHONE_TYPE_MOBILE);
       } else if (type.equals("home")) {
-        phoneNumber.setType(Person.PhoneType.HOME);
+        phoneNumber.setType(Person.PhoneType.PHONE_TYPE_HOME);
       } else if (type.equals("work")) {
-        phoneNumber.setType(Person.PhoneType.WORK);
+        phoneNumber.setType(Person.PhoneType.PHONE_TYPE_WORK);
       } else {
         stdout.println("Unknown phone type.  Using default.");
       }
@@ -531,13 +531,13 @@ class ListPeople {
 
       for (Person.PhoneNumber phoneNumber : person.getPhonesList()) {
         switch (phoneNumber.getType()) {
-          case MOBILE:
+          case PHONE_TYPE_MOBILE:
             System.out.print("  Mobile phone #: ");
             break;
-          case HOME:
+          case PHONE_TYPE_HOME:
             System.out.print("  Home phone #: ");
             break;
-          case WORK:
+          case PHONE_TYPE_WORK:
             System.out.print("  Work phone #: ");
             break;
         }

--- a/content/getting-started/kotlintutorial.md
+++ b/content/getting-started/kotlintutorial.md
@@ -262,12 +262,12 @@ fun promptPerson(): Person = person {
 
     print("Is this a mobile, home, or work phone? ")
     val type = when (readLine()) {
-      "mobile" -> Person.PhoneType.MOBILE
-      "home" -> Person.PhoneType.HOME
-      "work" -> Person.PhoneType.WORK
+      "mobile" -> Person.PhoneType.PHONE_TYPE_MOBILE
+      "home" -> Person.PhoneType.PHONE_TYPE_HOME
+      "work" -> Person.PhoneType.PHONE_TYPE_WORK
       else -> {
         println("Unknown phone type.  Using home.")
-        Person.PhoneType.HOME
+        Person.PhoneType.PHONE_TYPE_HOME
       }
     }
     phones += phoneNumber {
@@ -319,9 +319,9 @@ fun print(addressBook: AddressBook) {
     }
     for (phoneNumber in person.phonesList) {
       val modifier = when (phoneNumber.type) {
-        Person.PhoneType.MOBILE -> "Mobile"
-        Person.PhoneType.HOME -> "Home"
-        Person.PhoneType.WORK -> "Work"
+        Person.PhoneType.PHONE_TYPE_MOBILE -> "Mobile"
+        Person.PhoneType.PHONE_TYPE_HOME -> "Home"
+        Person.PhoneType.PHONE_TYPE_WORK -> "Work"
         else -> "Unknown"
       }
       println("  $modifier phone #: ${phoneNumber.number}")

--- a/content/getting-started/pythontutorial.md
+++ b/content/getting-started/pythontutorial.md
@@ -94,7 +94,7 @@ message Person {
 
   message PhoneNumber {
     optional string number = 1;
-    optional PhoneType type = 2 [default = HOME];
+    optional PhoneType type = 2 [default = PHONE_TYPE_HOME];
   }
 
   repeated PhoneNumber phones = 4;
@@ -125,7 +125,7 @@ even define message types nested inside other messages -- as you can see, the
 `PhoneNumber` type is defined inside `Person`. You can also define `enum` types
 if you want one of your fields to have one of a predefined list of values --
 here you want to specify that a phone number can be one of the following phone
-types: `MOBILE`, `HOME`, or `WORK`.
+types: `PHONE_TYPE_MOBILE`, `PHONE_TYPE_HOME`, or `PHONE_TYPE_WORK`.
 
 The " = 1", " = 2" markers on each element identify the unique "tag" that field
 uses in the binary encoding. Tag numbers 1-15 require one less byte to encode
@@ -240,7 +240,7 @@ person.name = "John Doe"
 person.email = "jdoe@example.com"
 phone = person.phones.add()
 phone.number = "555-4321"
-phone.type = addressbook_pb2.Person.HOME
+phone.type = addressbook_pb2.Person.PHONE_TYPE_HOME
 ```
 
 Note that these assignments are not just adding arbitrary new fields to a
@@ -262,7 +262,7 @@ any particular field definition, see the
 
 Enums are expanded by the metaclass into a set of symbolic constants with
 integer values. So, for example, the constant
-`addressbook_pb2.Person.PhoneType.WORK` has the value 2.
+`addressbook_pb2.Person.PhoneType.PHONE_TYPE_WORK` has the value 2.
 
 ### Standard Message Methods {#standard-message-methods}
 
@@ -348,11 +348,11 @@ def PromptForAddress(person):
 
     phone_type = input("Is this a mobile, home, or work phone? ")
     if phone_type == "mobile":
-      phone_number.type = addressbook_pb2.Person.PhoneType.MOBILE
+      phone_number.type = addressbook_pb2.Person.PhoneType.PHONE_TYPE_MOBILE
     elif phone_type == "home":
-      phone_number.type = addressbook_pb2.Person.PhoneType.HOME
+      phone_number.type = addressbook_pb2.Person.PhoneType.PHONE_TYPE_HOME
     elif phone_type == "work":
-      phone_number.type = addressbook_pb2.Person.PhoneType.WORK
+      phone_number.type = addressbook_pb2.Person.PhoneType.PHONE_TYPE_WORK
     else:
       print("Unknown phone type; leaving as default value.")
 
@@ -401,11 +401,11 @@ def ListPeople(address_book):
       print("  E-mail address:", person.email)
 
     for phone_number in person.phones:
-      if phone_number.type == addressbook_pb2.Person.PhoneType.MOBILE:
+      if phone_number.type == addressbook_pb2.Person.PhoneType.PHONE_TYPE_MOBILE:
         print("  Mobile phone #: ", end="")
-      elif phone_number.type == addressbook_pb2.Person.PhoneType.HOME:
+      elif phone_number.type == addressbook_pb2.Person.PhoneType.PHONE_TYPE_HOME:
         print("  Home phone #: ", end="")
-      elif phone_number.type == addressbook_pb2.Person.PhoneType.WORK:
+      elif phone_number.type == addressbook_pb2.Person.PhoneType.PHONE_TYPE_WORK:
         print("  Work phone #: ", end="")
       print(phone_number.number)
 

--- a/content/news/2023-08-09.md
+++ b/content/news/2023-08-09.md
@@ -1,6 +1,5 @@
 +++
 title = "Changes Announced on August 9, 2023"
-weight = 21
 linkTitle = "August 9, 2023"
 toc_hide = "true"
 description = "Changes announced for Protocol Buffers on August 9, 2023."

--- a/content/news/2023-08-15.md
+++ b/content/news/2023-08-15.md
@@ -1,0 +1,16 @@
++++
+title = "Changes Announced on August 15, 2023"
+linkTitle = "August 15, 2023"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers on August 15, 2023."
+type = "docs"
++++
+
+## Python Breaking Change
+
+In v25
+[`message.UnknownFields()`](https://googleapis.dev/python/protobuf/latest/google/protobuf/message.html#google.protobuf.message.Message.UnknownFields)
+will be deprecated in pure Python and C++ extensions. It will be removed in v26.
+Use the new
+[`UnknownFieldSet(message)`](https://googleapis.dev/python/protobuf/latest/google/protobuf/unknown_fields.html)
+support in `unknown_fields.py` as a replacement.

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -8,6 +8,8 @@ type = "docs"
 News topics provide information about past events and changes with Protocol
 Buffers, and plans for upcoming changes.
 
+*   [August 15, 2023](/news/2023-08-15) - Breaking Python
+    change with the replacement of `message.UnknownFields()``
 *   [August 9, 2023](/news/2023-08-09) - Support policy
     for .NET
 *   [July 17, 2023](/news/2023-07-17) - Dropping support

--- a/content/reference/java/java-generated.md
+++ b/content/reference/java/java-generated.md
@@ -63,6 +63,9 @@ enum, or message (including nested types) in the file with the same name,
     `java_outer_classname` is also set to the string `FooService`, then the
     wrapper class will generate a class name of `FooServiceOuterClass`.
 
+**Note:** If you are using the deprecated v1 of the protobuf API, `OuterClass`
+is added regardless of any collisions with message names.
+
 In addition to any nested classes, the wrapper class itself will have the
 following API (assuming the wrapper class is named `Foo` and was generated from
 `foo.proto`):
@@ -107,11 +110,6 @@ to read source code directly from JAR files. To output to a JAR file, simply
 provide an output location ending in `.jar`. Note that only the Java source code
 is placed in the archive; you must still compile it separately to produce Java
 class files.
-
-## Packages {#package}
-
-The generated class is placed in a Java package based on the `java_package`
-option. If the option is omitted, the `package` declaration is used instead.
 
 For example, if the `.proto` file contains:
 

--- a/content/reference/java/java-proto-names.md
+++ b/content/reference/java/java-proto-names.md
@@ -49,7 +49,9 @@ java_api_version | java_multiple_files | java_alt_api_package | java_package | j
     If the generated class name would be the same as one of the messages defined
     in the proto file, `derived_outer_class` has `OuterClass` appended to it.
     For example, if the proto is `foo_bar.proto` and contains a `FooBar`
-    message, the `$derived_outer_class` value is `FooBarOuterClass`.
+    message, the `$derived_outer_class` value is `FooBarOuterClass`. The same is
+    true when using the v1 API, whether or not the class name would be the same
+    as one of the messages defined.
 
 *   All other `$names` are the values of the corresponding proto2 file options
     defined in the proto file.


### PR DESCRIPTION
* Updates to enum values in the tutorials. This maps to https://github.com/protocolbuffers/protocolbuffers.github.io/pull/87/files

* A news entry for upcoming breaking changes in Python.

* Removing unnecessary weight metadata from a news entry.

* Adding information about how `OuterClass` is added to Java filenames when using the v1 API.

PiperOrigin-RevId: 558240789
Change-Id: Ic48d7e54a4b78fd649a477796939d10b357176e4