### PR TITLE
This change includes the following:

### DIFF
--- a/content/editions/overview.md
+++ b/content/editions/overview.md
@@ -1,5 +1,6 @@
 +++
 title = "Protobuf Editions Overview"
+linkTitle = "Overview"
 weight = 42
 description = "An overview of the Protobuf Editions functionality."
 type = "docs"

--- a/content/news/2023-09-15.md
+++ b/content/news/2023-09-15.md
@@ -1,0 +1,30 @@
++++
+title = "Changes announced on September 15, 2023"
+linkTitle = "September 15, 2023"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers on September 15, 2023."
+type = "docs"
++++
+
+## μpb Moving to the Protobuf Git Repository
+
+Starting with the v25 release, μpb now lives in the
+[protobuf repo](https://github.com/protocolbuffers/protobuf) instead
+of in its [former location](https://github.com/protocolbuffers/upb)
+in a separate repo. All μpb development going forward will take place only in
+the new location.
+
+The merger of the two repos will simplify and speed up our development process
+by removing the need to update pinned version dependencies between protobuf and
+μpb. Changes to μpb now take effect immediately in protobuf code and vice versa,
+without the need for a manual upgrade step.
+
+We expect that most users will not need to take much, if any, action to
+accommodate the change. μpb is the engine behind our Ruby, PHP, and Python
+implementations, but you will most likely not notice the change unless you have
+code that refers to μpb directly.
+
+If you refer to μpb from a Bazel project, you will need to update μpb references
+to point to protobuf instead (for example, replace `@upb` with
+`@com_google_protobuf`). We plan to keep μpb file paths and Bazel targets the
+same so that there is no need to make additional changes beyond that.

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -3,13 +3,16 @@ title = "News"
 weight = 20
 description = "Get the latest news about Protocol Buffers."
 type = "docs"
+no_list = "true"
 +++
 
 News topics provide information about past events and changes with Protocol
 Buffers, and plans for upcoming changes.
 
+*   [September 15, 2023](/news/2023-09-15) - μpb Moving
+    to the Protobuf GitHub repository
 *   [August 15, 2023](/news/2023-08-15) - Breaking Python
-    change with the replacement of `message.UnknownFields()``
+    change with the replacement of `message.UnknownFields()`
 *   [August 9, 2023](/news/2023-08-09) - Support policy
     for .NET
 *   [July 17, 2023](/news/2023-07-17) - Dropping support

--- a/content/overview.md
+++ b/content/overview.md
@@ -89,21 +89,14 @@ running on another platform.
 The following languages are supported directly in the protocol buffers compiler,
 protoc:
 
-*   [C++](/reference/cpp/cpp-generated/#invocation)
-
-*   [C#](/reference/csharp/csharp-generated/#invocation)
-
-*   [Java](/reference/java/java-generated/#invocation)
-
-*   [Kotlin](/reference/kotlin/kotlin-generated/#invocation)
-
-*   [Objective-C](/reference/objective-c/objective-c-generated/#invocation)
-
-*   [PHP](/reference/php/php-generated/#invocation)
-
-*   [Python](/reference/python/python-generated/#invocation)
-
-*   [Ruby](/reference/ruby/ruby-generated/#invocation)
+*   [C++](/reference/cpp/cpp-generated#invocation)
+*   [C#](/reference/csharp/csharp-generated#invocation)
+*   [Java](/reference/java/java-generated#invocation)
+*   [Kotlin](/reference/kotlin/kotlin-generated#invocation)
+*   [Objective-C](/reference/objective-c/objective-c-generated#invocation)
+*   [PHP](/reference/php/php-generated#invocation)
+*   [Python](/reference/python/python-generated#invocation)
+*   [Ruby](/reference/ruby/ruby-generated#invocation)
 
 The following languages are supported by Google, but the projects' source code
 resides in GitHub repositories. The protoc compiler uses plugins for these

--- a/content/programming-guides/encoding.md
+++ b/content/programming-guides/encoding.md
@@ -518,6 +518,11 @@ protocol buffer parsers must be able to parse fields in any order.
     *   `foo` and `bar` are concatenations of the same individual messages in a
         different order.
 
+## Encoded Proto Size Limitations {#size-limit}
+
+Protos must be smaller than 2 GiB when serialized. Many proto implementations
+will refuse to serialize or parse messages that exceed this limit.
+
 ## Condensed Reference Card {#cheat-sheet}
 
 The following provides the most prominent parts of the wire format in an

--- a/content/programming-guides/extension_declarations.md
+++ b/content/programming-guides/extension_declarations.md
@@ -1,0 +1,240 @@
++++
+title = "Extension Declarations"
+weight = 83
+description = "This topic describes in detail what extension declarations are, why we need them, and how we use them."
+type = "docs"
++++
+
+<!--*
+# Document freshness: For more information, see go/fresh-source.
+freshness: { owner: 'shaod' reviewed: '2023-09-06' }
+*-->
+
+## Introduction {#intro}
+
+This page describes in detail what extension declarations are, why we need them,
+and how we use them.
+
+**NOTE:** Extension declarations are used in proto2 only, as proto3 does not
+support extensions at this time.
+
+If you need an introduction to extensions, read this
+[extensions guide](https://protobuf.dev/programming-guides/proto2/#extensions)
+
+## Motivation {#motivation}
+
+Extension declarations aim to strike a happy medium between regular fields and
+extensions. Like extensions, they avoid creating a dependency on the message
+type of the field, which therefore results in a leaner build graph and smaller
+binaries in environments where unused messages are difficult or impossible to
+strip. Like regular fields, the field name/number appear in the enclosing
+message, which makes it easier to avoid conflicts and see a convenient listing
+of what fields are declared.
+
+Listing the occupied extension numbers with extension declarations makes it
+easier for users to pick an available extension number and to avoid conflicts.
+
+## Usage {#usage}
+
+Extension declarations are an option of extension ranges. Like forward
+declarations in C++, you can declare the field type, field name, and cardinality
+(singular or repeated) of an extension field without importing the `.proto` file
+containing the full extension definition:
+
+```proto
+syntax = "proto2";
+
+message Foo {
+  extensions 4 to 1000 [
+    declaration = {
+      number: 4,
+      full_name: ".my.package.event_annotations",
+      type: ".logs.proto.ValidationAnnotations",
+      repeated: true },
+    declaration = {
+      number: 999,
+      full_name: ".foo.package.bar",
+      type: "int32"}];
+}
+```
+
+This syntax has the following semantics:
+
+*   Multiple `declaration`s with distinct extension numbers can be defined in a
+    single extension range if the size of the range allows.
+*   If there is any declaration for the extension range, *all* extensions of the
+    range must also be declared. This prevents non-declared extensions from
+    being added, and enforces that any new extensions use declarations for the
+    range.
+*   The given message type (`.logs.proto.ValidationAnnotations`) does not need
+    to have been previously defined or imported. We check only that it is a
+    valid name that could potentially be defined in another `.proto` file.
+*   When this or another `.proto` file defines an extension of this message
+    (`Foo`) with this name or number, we enforce that the number, type, and full
+    name of the extension match what is forward-declared here.
+
+**WARNING:** Avoid using declarations for extension range groups such as
+`extensions 4, 999`. It is unclear which extension range the declarations apply
+to, and it is currently unsupported.
+
+The extension declarations expect two extension fields with different packages:
+
+```proto
+package my.package;
+extend Foo {
+  repeated logs.proto.ValidationAnnotations event_annotations = 4;
+}
+```
+
+```proto
+package foo.package;
+extend Foo {
+  optional int32 bar = 999;
+}
+```
+
+### Reserved Declarations {#reserved}
+
+An extension declaration can be marked `reserved: true` to indicate that it is
+no longer actively used and the extension definition has been deleted. **Do not
+delete the extension declaration or edit its `type` or `full_name` value**.
+
+This `reserved` tag is separate from the reserved keyword for regular fields and
+**does not require breaking up the extension range**.
+
+```proto {highlight="context:reserved"}
+syntax = "proto2";
+
+message Foo {
+  extensions 4 to 1000 [
+    declaration = {
+      number: 500,
+      full_name: ".my.package.event_annotations",
+      type: ".logs.proto.ValidationAnnotations",
+      reserved: true }];
+}
+```
+
+An extension field definition using a number that is `reserved` in the
+declaration will fail to compile.
+
+## Representation in descriptor.proto {#representation}
+
+Extension declaration is  represented in descriptor.proto as fields in
+`proto2.ExtensionRangeOptions`:
+
+```proto
+message ExtensionRangeOptions {
+  message Declaration {
+    optional int32 number = 1;
+    optional string full_name = 2;
+    optional string type = 3;
+    optional bool reserved = 5;
+    optional bool repeated = 6;
+  }
+  repeated Declaration declaration = 2;
+}
+```
+
+## Reflection Field Lookup {#reflection}
+
+Extension declarations are *not* returned from the normal field lookup functions
+like `Descriptor::FindFieldByName()` or `Descriptor::FindFieldByNumber()`. Like
+extensions, they are discoverable by extension lookup routines like
+`DescriptorPool::FindExtensionByName()`. This is an explicit choice that
+reflects the fact that declarations are not definitions and do not have enough
+information to return a full `FieldDescriptor`.
+
+Declared extensions still behave like regular extensions from the perspective of
+TextFormat and JSON. It also means that migrating an existing field to a
+declared extension will require first migrating any reflective use of that
+field.
+
+## Use Extension Declarations to Allocate Numbers {#recommendation}
+
+Extensions use field numbers just like ordinary fields do, so it is important
+for each extension to be assigned a number that is unique within the parent
+message. We recommend using extension
+declarations to declare the field
+number and type for each extension in the parent message. The extension
+declarations serve as a registry of all the parent message's extensions, and
+protoc will enforce that there are no field number conflicts. When you add a new
+extension, choose the number by just incrementing by one the previously added
+extension number. Whenever you delete an extension, make sure to mark the field
+number `reserved` to eliminate the risk of accidentally reusing
+it.
+
+This convention is only a recommendation--the protobuf team does not have the
+ability or desire to force anyone to adhere to it for every extendable message.
+If you as the owner of an extendable proto do not want to coordinate extension
+numbers through extension declarations, you can choose to provide coordination
+through other means. Be very careful, though,
+because accidental reuse of an extension number can cause serious problems.
+
+One way to sidestep the issue would be to avoid extensions entirely and use
+[`google.protobuf.Any`](/programming-guides/proto3/#any)
+instead. This could be a good choice for APIs that front storage or for
+pass-through systems where the client cares about the contents of the proto but
+the system receiving it does not.
+
+### Consequences of Reusing an Extension Number {#reusing}
+
+An extension is a field defined outside the container message; usually in a
+separate .proto file. This distribution of definitions makes it easy for two
+developers to accidentally create different definitions for the same extension
+field number.
+
+The consequences of changing an extension definition are the same for extensions
+and standard fields. Reusing a field number introduces an ambiguity in how a
+proto should be decoded from the wire format. The protobuf wire format is lean
+and doesn’t provide a good way to detect fields encoded using one definition and
+decoded using another.
+
+This ambiguity can manifest in a short time frame, such as a client using one
+extension definition and a server using another communicating
+.
+
+This ambiguity can also manifest over a longer time frame, such as storing data
+encoded using one extension definition and later retrieving and decoding using
+the second extension definition. This long-term case can be difficult to
+diagnose if the first extension definition was deleted after the data was
+encoded and stored.
+
+The outcome of this can be:
+
+1.  A parse error (best case scenario).
+2.  Leaked PII / SPII – if PII or SPII is written using one extension definition
+    and read using another extension definition.
+3.  Data Corruption – if data is read using the “wrong” definition, modified and
+    rewritten.
+
+Data definition ambiguity is almost certainly going to cost someone time for
+debugging at a minimum. It could also cause data leaks or corruption that takes
+months to clean up.
+
+## Usage Tips
+
+### Never Delete an Extension Declaration {#never-delete}
+
+Deleting an extension declaration opens the door to accidental reuse in the
+future. If the extension is no longer processed and the definition is deleted,
+the extension declaration can be [marked reserved](#reserved).
+
+### Never Use a Field Number from the `reserved` List for a New Extension Declaration {#never-reuse-reserved}
+
+Reserved numbers may have been used for fields or other extensions in the past.
+
+### Never change the type of an existing extension declaration {#never-change-type}
+
+Changing the extension field's type can result in data corruption.
+
+If the extension field is of an enum or message type, and that enum or message
+type is being renamed, updating the declaration name is required and safe. To
+avoid breakages, the update of the type, the extension field definition, and
+extension declaration should all happen in a single
+commit.
+
+### Use Caution When Renaming an Extension Field {#caution-renaming}
+
+While renaming an extension field is fine for the wire format, it can break JSON
+and TextFormat parsing.

--- a/content/reference/java/java-generated.md
+++ b/content/reference/java/java-generated.md
@@ -288,13 +288,15 @@ the `.proto` file uses lower-case with underscores
 ([as it should](/programming-guides/style)). The
 case-conversion works as follows:
 
-1.  For each underscore in the name, the underscore is removed, and the
+*   For each underscore in the name, the underscore is removed, and the
     following letter is capitalized.
-2.  If the name will have a prefix attached (e.g. "get"), the first letter is
+*   If the name will have a prefix attached (e.g. "get"), the first letter is
     capitalized. Otherwise, it is lower-cased.
+*   The letter following the last digit in each number in a method name is
+    capitalized.
 
 Thus, the field `foo_bar_baz` becomes `fooBarBaz`. If prefixed with `get`, it
-would be `getFooBarBaz`.
+would be `getFooBarBaz`. And `foo_ba23r_baz` becomes `fooBa23RBaz`.
 
 As well as accessor methods, the compiler generates an integer constant for each
 field containing its field number. The constant name is the field name converted


### PR DESCRIPTION
* Fixes a link title for the Editions overview topic
* Updates the configuration of the News index page
* Adds an entry to the News index page
* Adds a page to the News section of the site for upb moving repos
* Updates formatting of links in the overview topic
* Adds a section about proto size limitations to the Encoding topic
* Publishes the Extension Declarations topic
* Adds content to the Proto2 topic related to Extension Declarations
* Adds additional information abbout how Java method names are created from proto file names

PiperOrigin-RevId: 565422428
Change-Id: Ie2527c938f33d25a89d69cf4ccd19787556bdfbc