### PR TITLE
Update the BNF grammar to include multi-part option names

### DIFF
--- a/content/reference/protobuf/proto3-spec.md
+++ b/content/reference/protobuf/proto3-spec.md
@@ -151,7 +151,8 @@ language guide.
 
 ```
 option = "option" optionName  "=" constant ";"
-optionName = ( ident | "(" ["."] fullIdent ")" )
+optionName = optionNamePart { "." optionNamePart }
+optionNamePart = { ident | "(" ["."] fullIdent ")" }
 ```
 
 Example:


### PR DESCRIPTION
The BNF grammar on the [website](https://protobuf.dev/reference/protobuf/proto3-spec/#option) defines `option` like so:

```bnf
option = "option" optionName  "=" constant ";"
optionName = ( ident | "(" ["."] fullIdent ")" )
```

An `optionName` is either an identifier, or a full identifier (possibly starting with a period) wrapped in parenthesis . But later on in the same document there's an [example message](https://protobuf.dev/reference/protobuf/proto3-spec/#message_definition) which violates this definition. The example message includes an `optionName` that consists of multiple components.

```protobuf
message Outer {
  option (my_option).a = true;
  message Inner {   // Level 2
    int64 ival = 1;
  }
  map<int32, string> my_map = 2;
}
```

My change updates the documentation to parse the above example.

### In Search of Additional Evidence

* I [couldn't find](https://github.com/search?q=repo%3Aprotocolbuffers%2Fprotobuf%20bnf&type=code) a grammar definition in the official implementation.
*  The implementation contains a comment indicating names like `(my_option).a` are legal.
```cpp
  // Parses a single part of a multipart option name. A multipart name consists
  // of names separated by dots. Each name is either an identifier or a series
  // of identifiers separated by dots and enclosed in parentheses. E.g.,
  // "foo.(bar.baz).moo".
  bool ParseOptionNamePart(UninterpretedOption* uninterpreted_option,
                           const LocationRecorder& part_location,
                           const FileDescriptorProto* containing_file);
```

I have not grokked where/if this method is called, but it seems clear the grammar is incorrect.