### PR TITLE
This change includes the following:

### DIFF
--- a/content/editions/features.md
+++ b/content/editions/features.md
@@ -1,6 +1,6 @@
 +++
 title = "Feature Settings for Editions"
-weight = 42
+weight = 43
 description = "Protobuf Editions features and how they affect protobuf behavior."
 type = "docs"
 +++

--- a/content/programming-guides/style.md
+++ b/content/programming-guides/style.md
@@ -98,11 +98,14 @@ enum FooBar {
 ```
 
 Each enum value should end with a semicolon, not a comma. Prefer prefixing enum
-values instead of surrounding them in an enclosing message. The zero value enum
-should have the suffix `UNSPECIFIED`, because a server or application that gets
-an unexpected enum value will mark the field as unset in the proto instance. The
-field accessor will then return the default value, which for enum fields is the
-first enum value.
+values instead of surrounding them in an enclosing message.
+
+The zero value enum should have the suffix `UNSPECIFIED`, because a server or
+application that gets an unexpected enum value will mark the field as unset in
+the proto instance. The field accessor will then return the default value, which
+for enum fields is the first enum value. For more information on the unspecified
+enum value, see
+[the Proto Best Practices page](/programming-guides/dos-donts#unspecified-enum).
 
 ## Services {#services}
 

--- a/content/support/version-support.md
+++ b/content/support/version-support.md
@@ -47,7 +47,7 @@ The following sections provide a visual guide to the support for each language.
 
 ## C++ {#cpp}
 
-The C++ 4.24.x runtime was first released in 2023 Q3.
+The C++ 4.25.x runtime was first released in 2023 Q4.
 
 The C++ 3.21.x runtime was first released in 2022 Q2 and has support until 2024
 Q1.
@@ -116,16 +116,9 @@ C++ will target making major version bumps annually in Q1 of each year.
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4 class="green">PS</td>
-    <td title=24Q1 class="green">PS</td>
-    <td title=24Q2 class="green">PS</td>
-  </tr>
-  <tr>
-    <td colspan="13">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">25.x</td>
@@ -137,8 +130,15 @@ C++ will target making major version bumps annually in Q1 of each year.
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
+    <td title=24Q1 class="green">PS</td>
+    <td title=24Q2 class="green">PS</td>
+  </tr>
+  <tr>
+    <td colspan="13">
+      The cells below are projections of future releases, but are not guarantees
+      <br/>that those releases will happen, or that they will happen on that
+      schedule.
+    </td>
   </tr>
   <tr>
     <td class="gray">26.x</td>
@@ -152,6 +152,19 @@ C++ will target making major version bumps annually in Q1 of each year.
     <td title=23Q4></td>
     <td title=24Q1 class="blue">IR</td>
     <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">27.x</td>
+    <td class="gray">5.27.x</td>
+    <td title=22Q2></td>
+    <td title=22Q3></td>
+    <td title=22Q4></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2 class="blue">IR</td>
   </tr>
 </table>
 
@@ -188,68 +201,58 @@ For specific versions supported, see
 
 ## C&#35; {#csharp}
 
-The C# 3.24.x runtime was first released in 2023 Q3.
+The C# 3.25.x runtime was first released in 2023 Q4.
 
 <table>
   <tr>
     <th>protoc</th>
     <th>C#</th>
-    <th>22Q2</th>
-    <th>22Q3</th>
-    <th>22Q4</th>
     <th>23Q1</th>
     <th>23Q2</th>
     <th>23Q3</th>
     <th>23Q4</th>
     <th>24Q1</th>
-  </tr>
-  <tr>
-    <td class="gray">21.x</td>
-    <td class="gray">3.21.x</td>
-    <td title=22Q2 class="blue">IR</td>
-    <td title=22Q3 class="green">PS</td>
-    <td title=22Q4 class="green">PS</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
+    <th>24Q2</th>
   </tr>
   <tr>
     <td class="gray">22.x</td>
     <td class="gray">3.22.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1 class="blue">IR</td>
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">23.x</td>
     <td class="gray">3.23.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2 class="blue">IR</td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">24.x</td>
     <td class="gray">3.24.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4 class="green">PS</td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">25.x</td>
+    <td class="gray">3.25.x</td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4 class="blue">IR</td>
     <td title=24Q1 class="green">PS</td>
+    <td title=24Q2 class="green">PS</td>
   </tr>
   <tr>
     <td colspan="12">
@@ -259,28 +262,24 @@ The C# 3.24.x runtime was first released in 2023 Q3.
     </td>
   </tr>
   <tr>
-    <td class="gray">25.x</td>
-    <td class="gray"></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-  </tr>
-  <tr>
     <td class="gray">26.x</td>
     <td class="gray"></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1 class="blue">IR</td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">27.x</td>
+    <td class="gray"></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2 class="blue">IR</td>
   </tr>
 </table>
 
@@ -383,17 +382,10 @@ Java will target making major version bumps annually in Q1 of each year.
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4 class="green">PS</td>
-    <td title=24Q1 class="green">PS</td>
-    <td title=24Q2 class="green">PS</td>
-    <td title=24Q3 class="green">PS</td>
-  </tr>
-  <tr>
-    <td colspan="12">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
+    <td title=23Q4>
+    <td title=24Q1>
+    <td title=24Q2>
+    <td title=24Q3>
   </tr>
   <tr>
     <td class="gray">25.x</td>
@@ -405,9 +397,16 @@ Java will target making major version bumps annually in Q1 of each year.
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
+    <td title=24Q1 class="green">PS</td>
+    <td title=24Q2 class="green">PS</td>
+    <td title=24Q3 class="green">PS</td>
+  </tr>
+  <tr>
+    <td colspan="12">
+      The cells below are projections of future releases, but are not guarantees
+      <br/>that those releases will happen, or that they will happen on that
+      schedule.
+    </td>
   </tr>
   <tr>
     <td class="gray">26.x</td>
@@ -421,6 +420,20 @@ Java will target making major version bumps annually in Q1 of each year.
     <td title=23Q4></td>
     <td title=24Q1 class="blue">IR</td>
     <td title=24Q2></td>
+    <td title=24Q3></td>
+  </tr>
+  <tr>
+    <td class="gray">27.x</td>
+    <td class="gray">4.27.x</td>
+    <td title=22Q2></td>
+    <td title=22Q3></td>
+    <td title=22Q4></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2 class="blue">IR</td>
     <td title=24Q3></td>
   </tr>
 </table>
@@ -450,68 +463,58 @@ Java will target making major version bumps annually in Q1 of each year.
 
 ## Objective-C {#objc}
 
-The Objective-C 3.24.x runtime was first released in 2023 Q3.
+The Objective-C 3.25.x runtime was first released in 2023 Q4.
 
 <table>
   <tr>
     <th>protoc</th>
     <th>ObjC</th>
-    <th>22Q2</th>
-    <th>22Q3</th>
-    <th>22Q4</th>
     <th>23Q1</th>
     <th>23Q2</th>
     <th>23Q3</th>
     <th>23Q4</th>
     <th>24Q1</th>
-  </tr>
-  <tr>
-    <td class="gray">21.x</td>
-    <td class="gray">3.21.x</td>
-    <td title=22Q2 class="blue">IR</td>
-    <td title=22Q3 class="green">PS</td>
-    <td title=22Q4 class="green">PS</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
+    <th>24Q2</th>
   </tr>
   <tr>
     <td class="gray">22.x</td>
     <td class="gray">3.22.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1 class="blue">IR</td>
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">23.x</td>
     <td class="gray">3.23.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2 class="blue">IR</td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">24.x</td>
     <td class="gray">3.24.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4 class="green">PS</td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">25.x</td>
+    <td class="gray">3.25.x</td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4 class="blue">IR</td>
     <td title=24Q1 class="green">PS</td>
+    <td title=24Q2 class="green">PS</td>
   </tr>
   <tr>
     <td colspan="12">
@@ -521,28 +524,24 @@ The Objective-C 3.24.x runtime was first released in 2023 Q3.
     </td>
   </tr>
   <tr>
-    <td class="gray">25.x</td>
-    <td class="gray"></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-  </tr>
-  <tr>
     <td class="gray">26.x</td>
     <td class="gray"></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1 class="blue">IR</td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">27.x</td>
+    <td class="gray"></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2 class="blue">IR</td>
   </tr>
 </table>
 
@@ -571,68 +570,58 @@ The Objective-C 3.24.x runtime was first released in 2023 Q3.
 
 ## PHP {#php}
 
-The PHP 3.24.x runtime was first released in 2023 Q3.
+The PHP 3.25.x runtime was first released in 2023 Q4.
 
 <table>
   <tr>
     <th>protoc</th>
     <th>PHP</th>
-    <th>22Q2</th>
-    <th>22Q3</th>
-    <th>22Q4</th>
     <th>23Q1</th>
     <th>23Q2</th>
     <th>23Q3</th>
     <th>23Q4</th>
     <th>24Q1</th>
-  </tr>
-  <tr>
-    <td class="gray">21.x</td>
-    <td class="gray">3.21.x</td>
-    <td title=22Q2 class="blue">IR</td>
-    <td title=22Q3 class="green">PS</td>
-    <td title=22Q4 class="green">PS</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
+    <th>24Q2</th>
   </tr>
   <tr>
     <td class="gray">22.x</td>
     <td class="gray">3.22.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1 class="blue">IR</td>
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">23.x</td>
     <td class="gray">3.23.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2 class="blue">IR</td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">24.x</td>
     <td class="gray">3.24.x</td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4 class="green">PS</td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">25.x</td>
+    <td class="gray">3.25.x</td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4 class="blue">IR</td>
     <td title=24Q1 class="green">PS</td>
+    <td title=24Q2 class="green">PS</td>
   </tr>
   <tr>
     <td colspan="12">
@@ -642,28 +631,24 @@ The PHP 3.24.x runtime was first released in 2023 Q3.
     </td>
   </tr>
   <tr>
-    <td class="gray">25.x</td>
-    <td class="gray"></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-  </tr>
-  <tr>
     <td class="gray">26.x</td>
     <td class="gray"></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1 class="blue">IR</td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">27.x</td>
+    <td class="gray"></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2 class="blue">IR</td>
   </tr>
 </table>
 
@@ -700,7 +685,7 @@ For specific versions supported, see
 
 ## Python {#python}
 
-The Python 4.24.x runtime was first released in 2023 Q3.
+The Python 4.25.x runtime was first released in 2023 Q4.
 
 The Python 3.x runtime went out of support on July 1, 2023.
 
@@ -708,7 +693,6 @@ The Python 3.x runtime went out of support on July 1, 2023.
   <tr>
     <th>protoc</th>
     <th>Python</th>
-    <th>22Q2</th>
     <th>22Q3</th>
     <th>22Q4</th>
     <th>23Q1</th>
@@ -716,11 +700,11 @@ The Python 3.x runtime went out of support on July 1, 2023.
     <th>23Q3</th>
     <th>23Q4</th>
     <th>24Q1</th>
+    <th>24Q2</th>
   </tr>
   <tr>
     <td class="gray">20.x</td>
     <td class="gray">3.20.x</td>
-    <td title=22Q2 class="green">PS</td>
     <td title=22Q3 class="green">PS</td>
     <td title=22Q4 class="green">PS</td>
     <td title=23Q1 class="green">PS</td>
@@ -728,11 +712,11 @@ The Python 3.x runtime went out of support on July 1, 2023.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">21.x</td>
     <td class="gray">4.21.x</td>
-    <td title=22Q2 class="blue">IR</td>
     <td title=22Q3 class="green">PS</td>
     <td title=22Q4 class="green">PS</td>
     <td title=23Q1></td>
@@ -740,11 +724,11 @@ The Python 3.x runtime went out of support on July 1, 2023.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">22.x</td>
     <td class="gray">4.22.x</td>
-    <td title=22Q2></td>
     <td title=22Q3></td>
     <td title=22Q4></td>
     <td title=23Q1 class="blue">IR</td>
@@ -752,11 +736,11 @@ The Python 3.x runtime went out of support on July 1, 2023.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">23.x</td>
     <td class="gray">4.23.x</td>
-    <td title=22Q2></td>
     <td title=22Q3></td>
     <td title=22Q4></td>
     <td title=23Q1></td>
@@ -764,18 +748,31 @@ The Python 3.x runtime went out of support on July 1, 2023.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">24.x</td>
     <td class="gray">4.24.x</td>
-    <td title=22Q2></td>
     <td title=22Q3></td>
     <td title=22Q4></td>
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4 class="green">PS</td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">25.x</td>
+    <td class="gray">4.25.x</td>
+    <td title=22Q3></td>
+    <td title=22Q4></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4 class="blue">IR</td>
     <td title=24Q1 class="green">PS</td>
+    <td title=24Q2 class="green">PS</td>
   </tr>
   <tr>
     <td colspan="12">
@@ -785,21 +782,8 @@ The Python 3.x runtime went out of support on July 1, 2023.
     </td>
   </tr>
   <tr>
-    <td class="gray">25.x</td>
-    <td class="gray"></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=22Q4></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-  </tr>
-  <tr>
     <td class="gray">26.x</td>
     <td class="gray"></td>
-    <td title=22Q2></td>
     <td title=22Q3></td>
     <td title=22Q4></td>
     <td title=23Q1></td>
@@ -807,6 +791,19 @@ The Python 3.x runtime went out of support on July 1, 2023.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1 class="blue">IR</td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">27.x</td>
+    <td class="gray"></td>
+    <td title=22Q3></td>
+    <td title=22Q4></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2 class="blue">IR</td>
   </tr>
 </table>
 
@@ -843,7 +840,7 @@ For specific versions supported, see
 
 ## Ruby {#ruby}
 
-The Ruby 3.24.x runtime was first released in 2023 Q3.
+The Ruby 3.25.x runtime was first released in 2023 Q4.
 
 <table>
   <tr>
@@ -857,6 +854,7 @@ The Ruby 3.24.x runtime was first released in 2023 Q3.
     <th>23Q3</th>
     <th>23Q4</th>
     <th>24Q1</th>
+    <th>24Q2</th>
   </tr>
   <tr>
     <td class="gray">21.x</td>
@@ -869,6 +867,7 @@ The Ruby 3.24.x runtime was first released in 2023 Q3.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">22.x</td>
@@ -881,6 +880,7 @@ The Ruby 3.24.x runtime was first released in 2023 Q3.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">23.x</td>
@@ -893,6 +893,7 @@ The Ruby 3.24.x runtime was first released in 2023 Q3.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">24.x</td>
@@ -903,19 +904,13 @@ The Ruby 3.24.x runtime was first released in 2023 Q3.
     <td title=23Q1></td>
     <td title=23Q2></td>
     <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4 class="green">PS</td>
-    <td title=24Q1 class="green">PS</td>
-  </tr>
-  <tr>
-    <td colspan="10">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2></td>
   </tr>
   <tr>
     <td class="gray">25.x</td>
-    <td class="gray"></td>
+    <td class="gray">3.25.x</td>
     <td title=22Q2></td>
     <td title=22Q3></td>
     <td title=22Q4></td>
@@ -923,7 +918,15 @@ The Ruby 3.24.x runtime was first released in 2023 Q3.
     <td title=23Q2></td>
     <td title=23Q3></td>
     <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
+    <td title=24Q1 class="green">PS</td>
+    <td title=24Q2 class="green">PS</td>
+  </tr>
+  <tr>
+    <td colspan="10">
+      The cells below are projections of future releases, but are not guarantees
+      <br/>that those releases will happen, or that they will happen on that
+      schedule.
+    </td>
   </tr>
   <tr>
     <td class="gray">26.x</td>
@@ -936,6 +939,20 @@ The Ruby 3.24.x runtime was first released in 2023 Q3.
     <td title=23Q3></td>
     <td title=23Q4></td>
     <td title=24Q1 class="blue">IR</td>
+    <td title=24Q2></td>
+  </tr>
+  <tr>
+    <td class="gray">27.x</td>
+    <td class="gray"></td>
+    <td title=22Q2></td>
+    <td title=22Q3></td>
+    <td title=22Q4></td>
+    <td title=23Q1></td>
+    <td title=23Q2></td>
+    <td title=23Q3></td>
+    <td title=23Q4></td>
+    <td title=24Q1></td>
+    <td title=24Q2 class="blue">IR</td>
   </tr>
 </table>
 


### PR DESCRIPTION
* Reordering the table of contents by updating the weight metadata in the `features.md` topic
* Adding a link to the Proto best practices topic from within `style.md`
* Updating the `version-support.md` topic with information about the 25.x release

PiperOrigin-RevId: 579176393
Change-Id: Ie5b115b7d2405e2bbf04a668168f37a99f387d47