### PR TITLE
Periodic documentation update

### DIFF
--- a/content/editions/features.md
+++ b/content/editions/features.md
@@ -49,7 +49,7 @@ and after of a proto3 file.
 The following code sample shows a proto2 file:
 
 ```proto
-syntax = "proto2"
+syntax = "proto2";
 
 enum Foo {
   A = 2;
@@ -62,7 +62,7 @@ After running [Prototiller](#prototiller), the equivalent code might look like
 this:
 
 ```proto
-edition = "2023"
+edition = "2023";
 
 enum Foo {
   option features.enum_type = CLOSED;
@@ -104,7 +104,7 @@ for more information.
 The following code sample shows a proto2 file:
 
 ```proto
-syntax = "proto2"
+syntax = "proto2";
 
 message Foo {
   required int32 x = 1;
@@ -116,7 +116,7 @@ message Foo {
 After running Prototiller, the equivalent code might look like this:
 
 ```proto
-edition = "2023"
+edition = "2023";
 
 message Foo {
   int32 x = 1 [features.field_presence = LEGACY_REQUIRED];
@@ -140,7 +140,7 @@ message Bar {
 After running Prototiller, the equivalent code might look like this:
 
 ```proto
-edition = "2023"
+edition = "2023";
 option features.field_presence = IMPLICIT;
 
 message Bar {
@@ -227,7 +227,7 @@ and after of a proto3 file.
 The following code sample shows a proto2 file:
 
 ```proto
-syntax = "proto2"
+syntax = "proto2";
 
 message Foo {
   group Bar = 1 {
@@ -240,7 +240,7 @@ message Foo {
 After running Prototiller, the equivalent code might look like this:
 
 ```proto
-edition = "2023"
+edition = "2023";
 
 message Foo {
   message Bar {
@@ -275,7 +275,7 @@ for `repeated` fields has been migrated to in Editions.
 The following code sample shows a proto2 file:
 
 ```proto
-syntax = "proto2"
+syntax = "proto2";
 
 message Foo {
   repeated int32 bar = 6 [packed=true];
@@ -286,8 +286,8 @@ message Foo {
 After running Prototiller, the equivalent code might look like this:
 
 ```proto
-edition = "2023"
-options features.repeated_field_encoding = EXPANDED;
+edition = "2023";
+option features.repeated_field_encoding = EXPANDED;
 
 message Foo {
   repeated int32 bar = 6 [features.repeated_field_encoding=PACKED];
@@ -309,7 +309,7 @@ message Foo {
 After running Prototiller, the equivalent code might look like this:
 
 ```proto
-edition = "2023"
+edition = "2023";
 
 message Foo {
   repeated int32 bar = 6;
@@ -346,7 +346,7 @@ and after of a proto3 file.
 The following code sample shows a proto2 file:
 
 ```proto
-syntax = "proto2"
+syntax = "proto2";
 
 message MyMessage {
   string foo = 1;
@@ -356,7 +356,7 @@ message MyMessage {
 After running Prototiller, the equivalent code might look like this:
 
 ```proto
-edition = "2023"
+edition = "2023";
 
 message MyMessage {
   string foo = 1 [features.utf8_validation = NONE];
@@ -410,7 +410,7 @@ message Msg {
 After running Prototiller, the equivalent code might look like this:
 
 ```proto
-edition = "2023"
+edition = "2023";
 
 import "myproject/proto3file.proto";
 

--- a/content/editions/overview.md
+++ b/content/editions/overview.md
@@ -19,7 +19,7 @@ message, field, enum, and so on, that specify the behavior of protoc, the code
 generators, and protobuf runtimes. You can explicitly override a behavior at
 those different levels (file, message, field, ...) when your needs don't match
 the default behavior for the edition you've selected. You can also override your
-overrides. The [section later in this topic on inheritance](#inheritance) goes
+overrides. The [section later in this topic on lexical scoping](#scoping) goes
 into more detail on that.
 
 ## Lifecycle of a Feature {#lifecycles}
@@ -202,16 +202,19 @@ message Player {
 
 </section>
 
-### Inheritance {#inheritance}
+<a name="inheritance"></a>
 
-Editions syntax supports inheritance, with a per-feature list of allowed
+### Lexical Scoping {#scoping}
+
+Editions syntax supports lexical scoping, with a per-feature list of allowed
 targets. For example, in the first edition, features can be specified at only
-the file level or the lowest level of granularity. Inheritance enables you to
-set the default behavior for a feature across an entire file, and then override
-that behavior at the message, field, enum, enum value, oneof, service, or
-method. Settings made at a higher level (file, message) apply when no setting is
-made within the same scope (field, enum value). Any features not explicitly set
-conform to the behavior defined in the edition version used for the .proto file.
+the file level or the lowest level of granularity. The implementation of lexical
+scoping enables you to set the default behavior for a feature across an entire
+file, and then override that behavior at the message, field, enum, enum value,
+oneof, service, or method level. Settings made at a higher level (file, message)
+apply when no setting is made within the same scope (field, enum value). Any
+features not explicitly set conform to the behavior defined in the edition
+version used for the .proto file.
 
 The following code sample shows some features being set at the file, message,
 and enum level. The settings are in the highlighted lines:
@@ -243,7 +246,7 @@ message Person {
 
 In the preceding example, the presence feature is set to `IMPLICIT`; it would
 default to `EXPLICIT` if it wasn't set. The `Pay_Type` `enum` will be `CLOSED`,
-as it inherits the file-level setting. The `Employment` `enum`, though, will be
+as it applies the file-level setting. The `Employment` `enum`, though, will be
 `OPEN`, as it is set within the enum.
 
 ### Prototiller {#prototiller}

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "Tutorials"
 weight = 200

--- a/content/news/2023-08-15.md
+++ b/content/news/2023-08-15.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "Changes Announced on August 15, 2023"
 linkTitle = "August 15, 2023"

--- a/content/programming-guides/extension_declarations.md
+++ b/content/programming-guides/extension_declarations.md
@@ -221,9 +221,14 @@ Deleting an extension declaration opens the door to accidental reuse in the
 future. If the extension is no longer processed and the definition is deleted,
 the extension declaration can be [marked reserved](#reserved).
 
-### Never Use a Field Number from the `reserved` List for a New Extension Declaration {#never-reuse-reserved}
+### Never Use a Field Name or Number from the `reserved` List for a New Extension Declaration {#never-reuse-reserved}
 
 Reserved numbers may have been used for fields or other extensions in the past.
+
+Using the `full_name` of a reserved field
+is not recommended
+due
+to the possibility of ambiguity when using textproto.
 
 ### Never change the type of an existing extension declaration {#never-change-type}
 

--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -244,8 +244,9 @@ from an input stream.
     message type, as well as a special `Builder` class for creating message
     class instances.
 *   For **Kotlin**, in addition to the Java generated code, the compiler
-    generates a `.kt` file for each message type, containing a DSL which can be
-    used to simplify creating message instances.
+    generates a `.kt` file for each message type with an improved Kotlin API.
+    This includes a DSL that simplifies creating message instances, a nullable
+    field accessor, and a copy function.
 *   **Python** is a little different — the Python compiler generates a module
     with a static descriptor of each message type in your `.proto`, which is
     then used with a *metaclass* to create the necessary Python data access
@@ -518,7 +519,8 @@ type-specific:
 *   For strings, the default value is the empty string.
 *   For bytes, the default value is empty bytes.
 *   For bools, the default value is false.
-*   For numeric types, the default value is zero.
+*   For numeric types, the default value is zero. For float and double types,
+    -0.0 and 0.0 are treated as equivalent, and will round-trip.
 *   For enums, the default value is the **first defined enum value**, which must
     be 0.
 *   For message fields, the field is not set. Its exact value is
@@ -534,7 +536,8 @@ whether a boolean was set to `false`) or just not set at all: you should bear
 this in mind when defining your message types. For example, don't have a boolean
 that switches on some behavior when set to `false` if you don't want that
 behavior to also happen by default. Also note that if a scalar message field
-**is** set to its default, the value will not be serialized on the wire.
+**is** set to its default, the value will not be serialized on the wire. If a
+float or double value is set to -0 or +0, it will not be serialized.
 
 See the [generated code guide](/reference/) for your
 chosen language for more details about how defaults work in generated code.
@@ -875,10 +878,8 @@ fields that the parser does not recognize. For example, when an old binary
 parses data sent by a new binary with new fields, those new fields become
 unknown fields in the old binary.
 
-Originally, proto3 messages always discarded unknown fields during parsing, but
-in version 3.5 we reintroduced the preservation of unknown fields to match the
-proto2 behavior. In versions 3.5 and later, unknown fields are retained during
-parsing and included in the serialized output.
+Proto3 messages preserve unknown fields and includes them during parsing and in
+the serialized output, which matches proto2 behavior.
 
 ## Any {#any}
 

--- a/content/reference/cpp/api-docs/_index.md
+++ b/content/reference/cpp/api-docs/_index.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "C++ Reference"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.arena.md
+++ b/content/reference/cpp/api-docs/google.protobuf.arena.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "arena.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.compiler.ruby_generator.md
+++ b/content/reference/cpp/api-docs/google.protobuf.compiler.ruby_generator.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "ruby_generator.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.dynamic_message.md
+++ b/content/reference/cpp/api-docs/google.protobuf.dynamic_message.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "dynamic_message.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.map.md
+++ b/content/reference/cpp/api-docs/google.protobuf.map.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "map.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.message_lite.md
+++ b/content/reference/cpp/api-docs/google.protobuf.message_lite.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "message_lite.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.unknown_field_set.md
+++ b/content/reference/cpp/api-docs/google.protobuf.unknown_field_set.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "unknown_field_set.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.util.field_comparator.md
+++ b/content/reference/cpp/api-docs/google.protobuf.util.field_comparator.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "field_comparator.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.util.message_differencer.md
+++ b/content/reference/cpp/api-docs/google.protobuf.util.message_differencer.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "message_differencer.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.util.type_resolver.md
+++ b/content/reference/cpp/api-docs/google.protobuf.util.type_resolver.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "type_resolver.h"
 toc_hide = "true"

--- a/content/reference/cpp/api-docs/google.protobuf.util.type_resolver_util.md
+++ b/content/reference/cpp/api-docs/google.protobuf.util.type_resolver_util.md
@@ -1,3 +1,5 @@
+
+
 +++
 title = "type_resolver_util.h"
 toc_hide = "true"

--- a/content/reference/java/java-generated.md
+++ b/content/reference/java/java-generated.md
@@ -159,9 +159,9 @@ option optimize_for = LITE_RUNTIME;
 ```
 
 then `Foo` will include fast implementations of all methods, but will implement
-the `MessageLite` interface, which only contains a subset of the methods of
-`Message`. In particular, it does not support descriptors or reflection.
-However, in this mode, the generated code only needs to link against
+the `MessageLite` interface, which contains a subset of the methods of
+`Message`. In particular, it does not support descriptors, nested builders, or
+reflection. However, in this mode, the generated code only needs to link against
 `libprotobuf-lite.jar` instead of `libprotobuf.jar`. The "lite" library is much
 smaller than the full library, and is more appropriate for resource-constrained
 systems such as mobile phones.
@@ -488,10 +488,11 @@ The compiler will generate the following methods only in the message's builder:
     the specified index, or throws `IndexOutOfBoundsException` if the index is
     out of bounds.
 -   `Builder addFoosBuilder(int index)`: Inserts and returns a builder for a
-    default message instance at the specified index. The existing entries are
-    shifted to higher indices to make room for the inserted builder.
+    default message instance of the repeated message at the specified index. The
+    existing entries are shifted to higher indices to make room for the inserted
+    builder.
 -   `Builder addFoosBuilder()`: Appends and returns a builder for a default
-    message instance.
+    message instance of the repeated message.
 -   `Builder removeFoos(int index)`: Removes the element at the given zero-based
     index.
 -   `List<Builder> getFoosBuilderList()`: Returns the entire field as an

--- a/content/reference/protobuf/proto3-spec.md
+++ b/content/reference/protobuf/proto3-spec.md
@@ -151,7 +151,8 @@ language guide.
 
 ```
 option = "option" optionName  "=" constant ";"
-optionName = ( ident | "(" ["."] fullIdent ")" )
+optionName = optionNamePart { "." optionNamePart }
+optionNamePart = { ident | "(" ["."] fullIdent ")" }
 ```
 
 Example:

--- a/content/reference/protobuf/textformat-spec.md
+++ b/content/reference/protobuf/textformat-spec.md
@@ -266,6 +266,21 @@ any_value {
 }
 ```
 
+#### Unknown Fields (#unknown-fields)
+
+Text format parsers cannot support unknown fields represented as raw field
+numbers in place of field names because three of the six wire types are
+represented in the same way in textformat. Some text-format serializer
+implementations encode unknown fields with a format that uses a field number and
+a numeric representation of the value, but this is inherently lossy because the
+wire-type information is ignored. For comparison, wire-format is non-lossy
+because it includes the wire-type in each field tag as `(field_number << 3) |
+wire_type`. For more information on encoding, see the
+[Encoding](/programming-guides/encoding.md) topic.
+
+Without information about the field type from the message schema, the value
+cannot be correctly encoded into a wire-format proto message.
+
 ### Fields {#fields}
 
 Field values can be literals (strings, numbers, or identifiers), or nested

--- a/content/reference/python/python-generated.md
+++ b/content/reference/python/python-generated.md
@@ -534,6 +534,9 @@ foo.bars.add(i=3)
 foo.bars[0] = Bar(i=15)  # Raises an exception
 # WRONG!
 foo.bars[:] = [Bar(i=15), Bar(i=17)]  # Also raises an exception
+# RIGHT
+del foo.bars
+foo.bars.extend([Bar(i=15), Bar(i=17)])
 ```
 
 ### Groups (proto2) {#groups-proto2}
@@ -849,11 +852,10 @@ If the name of a message, field, enum, or enum value is a
 [Python keyword](https://docs.python.org/3/reference/lexical_analysis#keywords),
 then the name of its corresponding class or property will be the same, but
 you'll only be able to access it using Python's
-[`getattr()`](https://docs.python.org/3/library/functions#getattr)
-and
-[`setattr()`](https://docs.python.org/3/library/functions#setattr)
-built-in functions, and not via Python's normal attribute reference syntax (i.e.
-the dot operator).
+[`getattr()`](https://docs.python.org/3/library/functions#getattr) and
+[`setattr()`](https://docs.python.org/3/library/functions#setattr) built-in
+functions, and not via Python's normal attribute reference syntax (i.e. the dot
+operator).
 
 For example, if you have the following `.proto` definition:
 


### PR DESCRIPTION
The edits in this set include:

* Updated the section on inheritance in the Editions Overview topic to use the more-accurate term "lexical scoping."
* In the extension declarations topic, added clarification about using the `full_name` of a reserved field
* In the proto3 topic, added information about positive and negative zero in floats and doubles
* In the proto3 topic, added information about what files Kotlin generates and what they do
* In the proto3 topic, updates content about how unknown fields are handled to match current functionality
* Adds information to the Java topic about nested builder functionality that is not available in the Lite version
* Adds a section about unknown fields to the textformat spec topic
* Adds the proposed way to handle repeated message field assignments (previously only the ways NOT to do it were in the code sample)

PiperOrigin-RevId: 587099048
Change-Id: Id2a3709931ac12726a629f489ceffce27341fc6f