### PR TITLE
This update does the following:

### DIFF
--- a/content/news/2023-12-13.md
+++ b/content/news/2023-12-13.md
@@ -10,7 +10,7 @@ type = "docs"
 
 In v26, we are planning a major version bump for C++ as per our
 [breaking changes policy](/news/2022-07-06) and
-[version support policy](/support/version-support#python-support).
+[version support policy](/support/version-support#cpp-tooling).
 
 The following sections outline the set of breaking changes that we plan to
 include in the 26.0 release of protocol buffers. Note that plans can and do

--- a/content/news/2023-12-27.md
+++ b/content/news/2023-12-27.md
@@ -1,0 +1,54 @@
++++
+title = "Changes announced on December 27, 2023"
+linkTitle = "December 27, 2023"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers on December 27, 2023."
+type = "docs"
++++
+
+## Ruby Breaking Changes
+
+The following changes are planned for the 26.x line:
+
+*   Fix `RepeatedField#each_index` to have the correct semantics.
+    ([#11767](https://github.com/protocolbuffers/protobuf/pull/11767))
+*   Remove Ruby DSL and associated compatibility code, which will complete the
+    [migration announced in April](/news/2023-04-20).
+*   `Message#to_h` fixes:
+    *   Remove unset oneof fields.
+        ([#6167](https://github.com/protocolbuffers/protobuf/issues/6167))
+    *   Remove unset sub-message fields
+*   Use message's pool for
+    [`encode_json`](https://github.com/protocolbuffers/protobuf/blob/2fb0b93d9de226ea96f2dc2b4779eb4712d01d5c/ruby/ext/google/protobuf_c/message.c#L1118)/[`decode_json`](https://github.com/protocolbuffers/protobuf/blob/2fb0b93d9de226ea96f2dc2b4779eb4712d01d5c/ruby/ext/google/protobuf_c/message.c#L1004).
+*   Remove the deprecated syntax accessor, `FileDescriptor.syntax` and add
+    semantic checks in its place:
+    *   `FieldDescriptor.has_presence` to test if a field has presence.
+    *   `FieldDescriptor.is_packed` to test if a repeated field is packed.
+    *   `FieldDescriptor.requires_utf8_validation` to test if a string field
+        requires UTF-8 validation.
+    *   `EnumDescriptor.is_closed` to test if an enum is closed.
+
+## PHP Breaking Changes
+
+The following changes are planned for the 26.x line:
+
+*   Validate UTF-8 for string fields in setters.
+*   Remove generic services.
+    ([commit 40ad3fa](https://github.com/protocolbuffers/protobuf/commit/40ad3fac603ba3c96e52a1266cd785a7adb8e3e4))
+
+## Python Breaking Changes
+
+The following changes are planned for the 26.x line:
+
+*   Make `str(msg)` escape any invalid UTF-8 in string fields.
+*   Make `text_format.MessageToString()` default to outputting raw UTF-8, while
+    escaping any invalid UTF-8 sequences.
+*   Fix timestamp bounds ([commit 1250d5f](https://github.com/protocolbuffers/protobuf/commit/1250d5f6cccb0a45f959c7219980a0aad5060ee5))
+
+## upb Breaking Changes
+
+The following changes are planned for the 26.x line:
+
+*   Fix
+    [nonconformance in JSON parsing](https://github.com/protocolbuffers/protobuf/blob/2f7b2832b6a62fec88efacbb97bf0a91b6a3670e/upb/conformance/conformance_upb_failures.txt)
+    when `IgnoreUnknownEnumString` is enabled.

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -9,6 +9,8 @@ no_list = "true"
 News topics provide information about past events and changes with Protocol
 Buffers, and plans for upcoming changes.
 
+*   [December 27, 2023](/news/2023-12-27) - Breaking
+    changes in the 26.x line for Ruby, PHP, Python, and upb
 *   [December 13, 2023](/news/2023-12-13) - Breaking
     Python and C++ changes in the 26.x line
 *   [December 5, 2023](/news/2023-12-05) - Breaking Java

--- a/content/reference/go/go-generated.md
+++ b/content/reference/go/go-generated.md
@@ -216,10 +216,6 @@ an accessor method `GetBirthYear()` which returns the `int32` value in
 [zero value](https://golang.org/ref/spec#The_zero_value) of that type
 if the field is unset (`0` for numbers, the empty string for strings).
 
-The `FirstActiveYear` struct field will be of type `*int32`, and additionally
-have the `HasFirstActiveYear()` and `ClearFirstActiveYear()` accessors, because
-it is marked `optional`.
-
 For other scalar field types (including `bool`, `bytes`, and `string`), `int32`
 is replaced with the corresponding Go type according to the
 [scalar value types table](/programming-guides/proto3#scalar).


### PR DESCRIPTION
* Adds a new News article for upcoming breaking changes in Ruby, PHP, Python, and upb
* Removse a paragraph about `FirstActiveYear` struct fields in the Go Generated Code Guide

PiperOrigin-RevId: 594267305
Change-Id: I98b7ecd1985998644becb7aa810792818812539c