### PR TITLE
Documentation update

### DIFF
--- a/content/news/2024-02-27.md
+++ b/content/news/2024-02-27.md
@@ -1,0 +1,14 @@
++++
+title = "Changes Announced on February 27, 2024"
+linkTitle = "February 27, 2024"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers on February 27, 2024."
+type = "docs"
++++
+
+## Dropping Ruby 2.7 Support
+
+As per our official
+[Ruby support policy](https://cloud.google.com/ruby/getting-started/supported-ruby-versions),
+we will be dropping support for Ruby 2.7 and lower on March 31, 2024. The
+minimum supported Ruby version will be 3.0.

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -16,6 +16,8 @@ per-release topics, as some content is not tied to a version.
 The following news topics provide information in the reverse order in which it
 was released.
 
+*   [February 27, 2024](/news/2024-02-05) - Dropping
+    support for older versions of Ruby
 *   [February 5, 2024](/news/2024-02-05) - Breaking
     changes in Java, C++, and Python in the 26.x line.
 *   [January 31, 2024](/news/2024-01-31) - Breaking

--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -1052,8 +1052,8 @@ map<key_type, value_type> map_field = N;
 
 ...where the `key_type` can be any integral or string type (so, any
 [scalar](#scalar) type except for floating point types and `bytes`). Note that
-enum is not a valid `key_type`. The `value_type` can be any type except another
-map.
+neither enum nor proto messages are valid for `key_type`.
+The `value_type` can be any type except another map.
 
 So, for example, if you wanted to create a map of projects where each `Project`
 message is associated with a string key, you could define it like this:


### PR DESCRIPTION
These changes include the following:

* Adds a news entry for end of Ruby 2.7 support
* Adds information to the proto3 topic about using proto messages for `key_type`

PiperOrigin-RevId: 612841114
Change-Id: I8d0c2aab7e7bf6732456ac65c749ef2b9ecbeb8d