### PR TITLE
Documentation update

### DIFF
--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -16,7 +16,7 @@ per-release topics, as some content is not tied to a version.
 The following news topics provide information in the reverse order in which it
 was released.
 
-*   [February 27, 2024](/news/2024-02-05) - Dropping
+*   [February 27, 2024](/news/2024-02-27) - Dropping
     support for older versions of Ruby
 *   [February 5, 2024](/news/2024-02-05) - Breaking
     changes in Java, C++, and Python in the 26.x line.

--- a/content/programming-guides/style.md
+++ b/content/programming-guides/style.md
@@ -43,9 +43,10 @@ the protocol buffer type definitions.
 
 ## Message and Field Names {#message-field-names}
 
-Use PascalCase (with an initial capital) for message names – for example,
-`SongServerRequest`. Use lower_snake_case for field names (including oneof field
-and extension names) – for example, `song_name`.
+Use PascalCase (with an initial capital) for message names: `SongServerRequest`.
+Prefer to capitalize abbreviations as single words: `GetDnsRequest` rather than
+`GetDNSRequest`. Use lower_snake_case for field names, including oneof field and
+extension names: `song_name`.
 
 ```proto
 message SongServerRequest {

--- a/content/reference/protobuf/proto2-spec.md
+++ b/content/reference/protobuf/proto2-spec.md
@@ -408,7 +408,7 @@ service SearchService {
 ## Proto file {#proto_file}
 
 ```
-proto = syntax { import | package | option | topLevelDef | emptyStatement }
+proto = [syntax] { import | package | option | topLevelDef | emptyStatement }
 topLevelDef = message | enum | extend | service
 ```
 

--- a/content/reference/protobuf/proto3-spec.md
+++ b/content/reference/protobuf/proto3-spec.md
@@ -338,7 +338,7 @@ service SearchService {
 ## Proto File {#proto_file}
 
 ```
-proto = syntax { import | package | option | topLevelDef | emptyStatement }
+proto = [syntax] { import | package | option | topLevelDef | emptyStatement }
 topLevelDef = message | enum | service
 ```
 


### PR DESCRIPTION
This change includes the following:

* Fixes a link in the News home page
* Adds more guidance about message and field names
* Updates the proto2 and proto3 spec pages to indicate that the `syntax` element is optional in OSS projects

PiperOrigin-RevId: 613892885
Change-Id: I74fd02f808ec4e2fc48721226ca1a3d016563304