### PR TITLE
Fix protobuf examples at editions/overview.md

### DIFF
--- a/content/editions/overview.md
+++ b/content/editions/overview.md
@@ -229,16 +229,16 @@ message Person {
   int32 id = 2 [features.presence = IMPLICIT];
 
   enum Pay_Type {
-    PAY_TYPE_UNSPECIFIED = 1,
-    PAY_TYPE_SALARY = 2,
-    PAY_TYPE_HOURLY = 3
+    PAY_TYPE_UNSPECIFIED = 1;
+    PAY_TYPE_SALARY = 2;
+    PAY_TYPE_HOURLY = 3;
   }
 
   enum Employment {
     option features.enum_type = OPEN;
-    EMPLOYMENT_UNSPECIFIED = 0,
-    EMPLOYMENT_FULLTIME = 1,
-    EMPLOYMENT_PARTTIME = 2,
+    EMPLOYMENT_UNSPECIFIED = 0;
+    EMPLOYMENT_FULLTIME = 1;
+    EMPLOYMENT_PARTTIME = 2;
   }
   Employment employment = 4;
 }
@@ -270,9 +270,9 @@ definition files, and vice versa:
 syntax = "proto2";
 
 enum Employment {
-  EMPLOYMENT_UNSPECIFIED = 0,
-  EMPLOYMENT_FULLTIME = 1,
-  EMPLOYMENT_PARTTIME = 2,
+  EMPLOYMENT_UNSPECIFIED = 0;
+  EMPLOYMENT_FULLTIME = 1;
+  EMPLOYMENT_PARTTIME = 2;
 }
 ```
 


### PR DESCRIPTION
Lexical Scoping protobuf examples is invalid.

```
$ cat person.proto
edition = "2023";

option features.enum_type = CLOSED;

message Person {
  string name = 1;
  int32 id = 2 [features.presence = IMPLICIT];

  enum Pay_Type {
    PAY_TYPE_UNSPECIFIED = 1,
    PAY_TYPE_SALARY = 2,
    PAY_TYPE_HOURLY = 3
  }

  enum Employment {
    option features.enum_type = OPEN;
    EMPLOYMENT_UNSPECIFIED = 0,
    EMPLOYMENT_FULLTIME = 1,
    EMPLOYMENT_PARTTIME = 2,
  }
  Employment employment = 4;
}

$ protoc --go_out=./my_proto --go_opt=paths=source_relative person.proto
person.proto:10:29: Expected ";".
person.proto:17:31: Expected ";".
```

In this PR, fix using valid protobuf.
