### PR TITLE
Document the `ruby_package` file option on the Ruby Generated Code Guide page

### DIFF
--- a/content/programming-guides/dos-donts.md
+++ b/content/programming-guides/dos-donts.md
@@ -208,6 +208,8 @@ For example:
     https://google.github.io/styleguide/cppguide.html#Namespace_Names.
     If these style guides conflict, use `java_package` for Java.
 
+*   `ruby_package` should be in the form `Foo::Bar::Baz`, not `Foo.Bar.Baz`.
+
 <a id="never-use-text-format-messages-for-interchange"></a>
 
 ## **Don't** use Text Format Messages for Interchange {#text-format-interchange}

--- a/content/reference/ruby/ruby-generated.md
+++ b/content/reference/ruby/ruby-generated.md
@@ -56,6 +56,15 @@ message MyMessage {}
 The protocol compiler generates an output message with the name
 `FooBar::Baz::MyMessage`.
 
+However, if the `.proto` file contains the `ruby_package` option, like this:
+
+```proto
+option ruby_package = "Foo::Bar";
+```
+
+Then the generated output will give precedence to the `ruby_package` option
+instead and generate `Foo::Bar::MyMessage`.
+
 ## Messages {#message}
 
 Given a simple message declaration:


### PR DESCRIPTION
Closes https://github.com/protocolbuffers/protobuf/issues/8853 by adding the [`ruby_package` option](https://github.com/protocolbuffers/protobuf/pull/4627) to the Ruby Generated Code Guide page.

Make a note on the Do/Don't page that the `ruby_package` should be `::` delimited.