### PR TITLE
Clarify that lookup/resolve/descriptor are singleton class methods

### DIFF
--- a/content/reference/ruby/ruby-generated.md
+++ b/content/reference/ruby/ruby-generated.md
@@ -357,12 +357,12 @@ end
 
 An enum module also defines the following utility methods:
 
--   `Enum#lookup(number)`: Looks up the given number and returns its name, or
+-   `Foo::SomeEnum.lookup(number)`: Looks up the given number and returns its name, or
     `nil` if none was found. If more than one name has this number, returns the
     first that was defined.
--   `Enum#resolve(symbol)`: Returns the number for this enum name, or `nil` if
+-   `Foo::SomeEnum.resolve(symbol)`: Returns the number for this enum name, or `nil` if
     none was found.
--   `Enum#descriptor`: Returns the descriptor for this enum.
+-   `Foo::SomeEnum.descriptor`: Returns the descriptor for this enum.
 
 ## Oneof
 


### PR DESCRIPTION
The Ruby documentation uses `#` exclusively to mean "an instance method," for example [in the Array documentation](https://docs.ruby-lang.org/en/master/Array.html), making its usage here in the protobuf docs misleading: using `#` here makes it seem like you're supposed to call this method on instances of the enum module, but there are none.

In general, writing it like this in terms of `Foo::SomeEnum` brings the example more in line with the rest of the examples which all operate on a hypothetical enum module.