### PR TITLE
Remove section about option deadline

### DIFF
--- a/content/programming-guides/api.md
+++ b/content/programming-guides/api.md
@@ -730,31 +730,6 @@ your service name, even if it is defined inside a specific package. For example,
 a service named `Watcher` is likely to cause problems; something like
 `MyProjectWatcher` would be better.
 
-## Ensure Every RPC Specifies and Enforces a (Permissive) Deadline {#every-rpc-deadline}
-
-By default, an RPC does not have a timeout. Since a request may tie up backend
-resources that are only released on completion, setting a default deadline that
-allows all well-behaving requests to finish is a good defensive practice. Not
-enforcing one has in the past caused
-severe problems for major services . RPC clients
-should still set a deadline on outgoing RPCs and will typically do so by default
-when they use standard frameworks. A deadline may and typically will be
-overwritten by a shorter deadline attached to a request.
-
-Setting the `deadline` option clearly communicates the RPC
-deadline to your clients, and is respected and enforced by standard frameworks:
-
-```proto
-rpc Foo(FooRequest) returns (FooResponse) {
-  option deadline = x; // there is no globally good default
-}
-```
-
-Choosing a deadline value will especially impact how your system acts under
-load. For existing services, it is critical to evaluate existing client behavior
-before enforcing new deadlines to avoid breaking clients (consult SRE). In some
-cases, it may not be possible to enforce a shorter deadline after the fact.
-
 ## Bound Request and Response Sizes {#bound-req-res-sizes}
 
 Request and response sizes should be bounded.


### PR DESCRIPTION
### Why?
It's a google-internal option that just doesn't exist in the open-source protobuf. This documentation is misleading. 