### PR TITLE
Documentation change

### DIFF
--- a/content/editions/overview.md
+++ b/content/editions/overview.md
@@ -269,8 +269,11 @@ as it applies the file-level setting. The `Employment` `enum`, though, will be
 
 ### Prototiller {#prototiller}
 
-We provide both a migration guide and migration tooling that ease the migration
-to and between editions. The tool, called Prototiller, will enable you to:
+Currently, all conversions to editions format are handled by the Protobuf team.
+
+When this shifts to a self-serve model, we will provide both a migration guide
+and migration tooling to ease the migration to and between editions. The tool,
+called Prototiller, will enable you to:
 
 *   convert proto2 and proto3 definition files to the new editions syntax, at
     scale

--- a/content/programming-guides/dos-donts.md
+++ b/content/programming-guides/dos-donts.md
@@ -159,7 +159,7 @@ their own file with no dependencies. Then it's easy for anyone to use those
 types without introducing the transitive dependencies in your other proto files.
 
 For more on this topic, see
-[1-1-1 Rule](/programming-guides/1-1-1.md).
+[1-1-1 Rule](/programming-guides/1-1-1).
 
 <a id="dont-change-the-default-value-of-a-field"></a>
 

--- a/content/programming-guides/encoding.md
+++ b/content/programming-guides/encoding.md
@@ -227,7 +227,7 @@ specify a `double` record by writing `5: 25.4`, or a `fixed64` record with `6:
 type.
 
 Similarly `float` and `fixed32` have wire type `I32`, which tells it to expect
-four bytes instead. The syntax for these consists of adding an `i32` prefix.
+four bytes instead. The syntax for these consists of adding an `i32` suffix.
 `25.4i32` will emit four bytes, as will `200i32`. Tag types are inferred as
 `I32`.
 
@@ -260,7 +260,7 @@ encoding of `"testing"`. The int32 varint means that the max length of a string
 is 2GB.
 
 In Protoscope, this is written as `2:LEN 7 "testing"`. However, it can be
-incovenient to repeat the length of the string (which, in Protoscope text, is
+inconvenient to repeat the length of the string (which, in Protoscope text, is
 already quote-delimited). Wrapping Protoscope content in braces will generate a
 length prefix for it: `{"testing"}` is a shorthand for `7 "testing"`. `{}` is
 always inferred by fields to be a `LEN` record, so we can write this record

--- a/content/support/migration.md
+++ b/content/support/migration.md
@@ -138,14 +138,13 @@ After:
 
 ```cpp
 #include <google/protobuf/util/time_util.h>
-#ifdef GetCurrent
+#ifdef GetCurrentTime
 #undef GetCurrentTime
 #endif
 
 void F() {
   auto time = google::protobuf::util::TimeUtil::GetCurrentTime();
 }
-
 ```
 
 **Example 2: Preventing macro expansion**


### PR DESCRIPTION
This documentation change includes the following:

* An update to the Prototiller documentation to clarify that its use is solely for the Proto team for the time being
* Fixes a broken link
* Replaces the word "prefix" with "suffix" in the encoding topic
* Fixes a bug in an example in the migration guide.

PiperOrigin-RevId: 666823914
Change-Id: I37bd9686a9ed7b1f04cf6cb24cebf99e56fc51eb