### PR TITLE
Documentation updates

### DIFF
--- a/content/includes/version-tables.css
+++ b/content/includes/version-tables.css
@@ -32,3 +32,119 @@ tbody td.gray {
 tbody td.yellow {
   background: #fff2cc;
 }
+
+/* version-table */
+
+table.version-table tr.end-of-life th {
+  background: #f4cccc;
+}
+table.version-table tr.internal-support th {
+  background: #fce5cd;
+}
+table.version-table tr.maintenance th {
+  background: #fff2cc;
+}
+table.version-table tr.active th {
+  background: #d9ead3;
+  text-decoration: underline;
+}
+table.version-table tr.future th {
+  background: #fff;
+}
+table.version-table tr.future td {
+  font-style: italic;
+}
+
+table.version-table td:nth-child(4) {
+  text-align: start;
+}
+
+/* version-chart */
+
+table.version-chart tr.end-of-life th {
+  background: #f4cccc;
+}
+table.version-chart tr.internal-support th {
+  background: #fce5cd;
+}
+table.version-chart tr.maintenance th {
+  background: #fff2cc;
+}
+table.version-chart tr.active th {
+  background: #d9ead3;
+  text-decoration: underline;
+}
+table.version-chart tr.future th {
+  background: #fff;
+}
+table.version-chart tr.future td {
+  font-style: italic;
+}
+
+table.version-chart td.internal-support {
+  background: #fce5cd;
+}
+table.version-chart td.maintenance {
+  background: #fff2cc;
+}
+table.version-chart td.active {
+  background: #d9ead3;
+  text-decoration: underline;
+}
+
+/* latest release column */
+
+/* visually replace 'yyQq' heading with string 'Latest' */
+table.version-chart th.latest-release span {
+  display: none;
+}
+table.version-chart th.latest-release::after {
+  content: "Latest"
+}
+
+/* draw a focus rectangle around the latest release column */
+table.version-chart th.latest-release {
+  border-top: 2px solid #e06666 !important;
+  border-left: 2px solid #e06666 !important;
+  border-right: 2px solid #e06666 !important;
+}
+table.version-chart td.latest-release {
+  font-weight: bold;
+  border-left: 2px solid #e06666 !important;
+  border-right: 2px solid #e06666 !important;
+}
+table.version-chart tr:last-child td.latest-release {
+  border-bottom: 2px solid #e06666 !important;
+}
+
+/* future release columns */
+table.version-chart td:not(:has(~ .latest-release)):not(.latest-release) {
+  font-style: italic;
+}
+
+/* legend */
+
+table.legend th {
+  font-weight: normal;
+}
+
+table.legend tr.end-of-life th {
+  background: #f4cccc;
+}
+table.legend tr.internal-support th {
+  background: #fce5cd;
+}
+table.legend tr.maintenance th {
+  background: #fff2cc;
+}
+table.legend tr.active th {
+  background: #d9ead3;
+  text-decoration: underline;
+}
+table.legend tr.future th {
+  background: #fff;
+}
+
+table.legend td:nth-child(2) {
+  text-align: start;
+}

--- a/content/news/2024-11-07.md
+++ b/content/news/2024-11-07.md
@@ -1,0 +1,76 @@
++++
+title = "Changes Announced on November 7, 2024"
+linkTitle = "November 7, 2024"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers on November 7, 2024."
+type = "docs"
++++
+
+The following sections cover planned breaking changes in the v30 release,
+expected in 2025 Q1. Also included are some changes that aren't breaking but may
+require action on your part. These are in addition to those mentioned in the
+[News article from October 2](/news/2024-10-02).
+
+These describe changes as we anticipate them being implemented, but due to the
+flexible nature of software some of these changes may not land or may vary from
+how they are described in this topic.
+
+## Introduce ASAN Poisoning After Clearing Oneof Messages on Arena
+
+This change adds a hardening check that affects C++ protobufs using Arenas.
+Oneof messages allocated on the protobuf arena will now be cleared in debug and
+poisoned in ASAN mode. After calling clear, future attempts to use the memory
+region will cause a crash in ASAN as a use-after-free error.
+
+This implementation
+[requires C++17](/news/2024-10-02#drop-cpp-14).
+
+## Python setdefault Behavior Change for Map Fields
+
+Starting in v30, `setdefault` will be similar to `dict` for `ScalarMap`, except
+that both key and value must be set. `setdefault` will be rejected for
+`MessageMaps`.
+
+## Remove Deprecated py_proto_library Macro
+
+The deprecated internal `py_proto_library` Bazel macro in `protobuf.bzl` will be
+removed in v30.x.
+
+This should be replaced by the official `py_proto_library` which will be moved
+to protobuf in `bazel/py_proto_library` as of v29.x. This implementation was
+previously available in `rules_python` prior to v29.x.
+
+## Python Nested Message Class \_\_qualname\_\_ Contains the Outer Message Name
+
+Python nested message class `__qualname__` now contains the outer message name.
+Prior to v30, `__qualname__` has the same result with `__name__` for nested
+message, in that the outer message name was not included.
+
+For example:
+
+```python
+message Foo {
+  message Bar {
+    bool bool_field = 1;
+  }
+}
+nested = test_pb2.Foo.Bar()
+self.assertEqual('Bar', nested.__class__.__name__)
+self.assertEqual('Foo.Bar', nested.__class__.__qualname__) # It was 'Bar' before
+```
+
+## Dropping our C++ CocoaPods release
+
+In v30, we will be dropping our C++ CocoaPods release, which has been broken
+since v4.x.x. C++ users should use our
+[GitHub release](https://github.com/protocolbuffers/protobuf/releases) directly
+instead.
+
+## Ruby and PHP Errors in JSON Parsing
+
+v30 fixes non-conformance in JSON parsing of strings in numeric fields per the
+[JSON spec](https://protobuf.dev/programming-guides/json/).
+
+This fix will not be accompanied by a major version bump, but Ruby and PHP will
+now raise errors for non-numeric strings (e.g. "", "12abc", "abc") in numeric
+fields. v29.x will include a warning for these error cases.

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -20,6 +20,8 @@ New news topics will also be published to the
 The following news topics provide information in the reverse order in which it
 was released.
 
+*   [November 7, 2024](/news/2024-11-07) - More breaking
+    changes in the upcoming 30.x release
 *   [October 2, 2024](/news/2024-10-02) - Breaking
     changes in the upcoming 30.x release
 *   [October 1, 2024](/news/2024-10-01) - Changes to
@@ -84,6 +86,7 @@ release notes will be more complete. Also, not everything from the chronological
 listing will be in these topics, as some content is not specific to a particular
 release.
 
+*   [Version 30.x](/news/v30)
 *   [Version 29.x](/news/v29)
 *   [Version 26.x](/news/v26)
 *   [Version 25.x](/news/v25)

--- a/content/news/v30.md
+++ b/content/news/v30.md
@@ -1,0 +1,326 @@
++++
+title = "News Announcements for Version 30.x"
+linkTitle = "Version 30.x"
+toc_hide = "true"
+description = "Changes announced for Protocol Buffers version 30.x."
+type = "docs"
++++
+
+The following announcements are specific to Version 30.x. For information
+presented chronologically, see [News](/news).
+
+The following sections cover planned breaking changes in the v30 release,
+expected in 2025 Q1. These describe changes as we anticipate them being
+implemented, but due to the flexible nature of software some of these changes
+may not land or may vary from how they are described in this topic.
+
+## Changes in C++ {#cpp}
+
+C++ will bump its major version from 5.29.x to 6.30.x.
+
+### Descriptor APIs {#descriptor-apis}
+
+v30 will update return types in descriptor (such as `full_name`) to be
+`absl::string_view`. This opens up memory savings in descriptors.
+
+v28 introduced the `PROTOBUF_FUTURE_STRING_VIEW_RETURN_TYPE` macro, which you
+can use in the meantime to enable the updated return type ahead of the breaking
+release. The v30 release will flip the default and remove the macro.
+
+### ctype Removed from FieldDescriptor Options {#ctype-removed}
+
+v30 will stop exposing the `ctype` from `FieldDescriptor` options. You can use
+the `FieldDescriptor::cpp_string_type()` API, added in the
+[v28 release](https://github.com/protocolbuffers/protobuf/releases/tag/v28.0),
+in its place.
+
+### Replace CMake Submodules with Fetched Deps {#replace-cmake-submods}
+
+v30 will remove submodules and switches to upb's old CMake pattern of fetching
+dependencies.
+
+If you use installed packages, you won't be affected. It could break some CMake
+workflows.
+
+### Remove Deprecated APIs {#remove-deprecated}
+
+v30 will remove the following public runtime APIs, which have been marked
+deprecated (such as `ABSL_DEPRECATED`) for at least one minor or major release
+and that are obsolete or replaced.
+
+#### Arena::CreateMessage
+
+**API:**
+[`Arena::CreateMessage`](https://github.com/protocolbuffers/protobuf/blob/f4b57b98b08aec8bc52e6a7b762edb7a1b9e8883/src/google/protobuf/arena.h#L179)
+
+**Replacement:**
+[`Arena::Create`](https://github.com/protocolbuffers/protobuf/blob/f4b57b98b08aec8bc52e6a7b762edb7a1b9e8883/src/google/protobuf/arena.h#L191)
+
+#### Arena::GetArena
+
+**API:**
+[`Arena::GetArena`](https://github.com/protocolbuffers/protobuf/blob/237332ef92daf83a53e76decd6ac43c3fcee782b/src/google/protobuf/arena.h#L346)
+
+**Replacement:** `value->GetArena()`
+
+#### RepeatedPtrField::ClearedCount
+
+**API:**
+[`RepeatedPtrField::ClearedCount`](https://github.com/protocolbuffers/protobuf/blame/f4b57b98b08aec8bc52e6a7b762edb7a1b9e8883/src/google/protobuf/repeated_ptr_field.h#L1157)
+
+**Replacement:** Migrate to Arenas
+([migration guide](https://protobuf.dev/support/migration/#cleared-elements)).
+
+#### JsonOptions
+
+**API:**
+[`JsonOptions`](https://github.com/protocolbuffers/protobuf/blob/f4b57b98b08aec8bc52e6a7b762edb7a1b9e8883/src/google/protobuf/util/json_util.h#L22)
+
+**Replacement:** `JsonPrintOptions`
+
+### Dropping C++14 Support {#drop-cpp-14}
+
+This release will drop C++ 14 as the minimum supported version and raise it to
+17, as per the
+[Foundational C++ Support matrix](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md).
+
+Per [our policies](https://protobuf.dev/support/version-support/), we do not
+consider this to be a breaking change.
+
+## Changes in JRuby {#jruby}
+
+v30 will flip the default implementation for JRuby to FFI, which may be breaking
+for some JRuby users.
+
+Note that this change doesn't create a Ruby major version bump because JRuby is
+[not officially supported](/support/version-support/#ruby).
+
+## Changes in Python {#python}
+
+Python will bump its major version from 5.29.x to 6.30.x.
+
+### Dropping Python 3.8 Support
+
+As per our official Python support policy, we will be dropping support for
+Python 3.8 and lower. This means the minimum supported Python version is 3.9.
+
+### Remove bazel/system_python.bzl Alias {#python-remove-alias}
+
+v30 will remove the legacy `bazel/system_python.bzl` alias.
+
+Remove direct references to `system_python.bzl` in favor of using
+`protobuf_deps.bzl` instead. Use `python/dist/system_python.bzl` where it was
+moved
+[in v5.27.0](https://github.com/protocolbuffers/protobuf/commit/d7f032ad1596ceeabd45ca1354516c39b97b2551)
+if you need a direct reference.
+
+### Field Setter Validation Changes {#python-setter-validation}
+
+Python's and upb's field setters will be fixed in v30 to validate closed enums
+under edition 2023. Closed enum fields updated with invalid values will generate
+errors.
+
+### Remove Deprecated APIs {#python-remove-apis}
+
+v30 will remove the following public runtime APIs, which have been marked
+deprecated for at least one minor or major release and are obsolete or replaced.
+
+#### Reflection Methods
+
+**APIs:**
+[`reflection.ParseMessage`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/reflection.py#L40),
+[`reflection.MakeClass`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/reflection.py#L66)
+
+**Replacement:** `message_factory.GetMessageClass()`
+
+#### RPC Service Interfaces
+
+**APIs:**
+[`service.RpcException`](https://github.com/protocolbuffers/protobuf/blob/21c545c8c5cec0b052dc7715b778f0353d37d02c/python/google/protobuf/service.py#L23),
+[`service.Service`](https://github.com/protocolbuffers/protobuf/blob/21c545c8c5cec0b052dc7715b778f0353d37d02c/python/google/protobuf/service.py#L28),
+[`service.RpcController`](https://github.com/protocolbuffers/protobuf/blob/21c545c8c5cec0b052dc7715b778f0353d37d02c/python/google/protobuf/service.py#L97),
+and
+[`service.RpcChannel`](https://github.com/protocolbuffers/protobuf/blob/21c545c8c5cec0b052dc7715b778f0353d37d02c/python/google/protobuf/service.py#L180)
+
+**Replacement:** Starting with version 2.3.0, RPC implementations should not try
+to build on these, but should instead provide code generator plugins which
+generate code specific to the particular RPC implementation.
+
+#### MessageFactory and SymbolDatabase Methods
+
+**APIs:**
+[`MessageFactory.GetPrototype`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/message_factory.py#L145),
+[`MessageFactory.CreatePrototype`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/message_factory.py#L165),
+[`MessageFactory.GetMessages`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/message_factory.py#L185),
+[`SymbolDatabase.GetPrototype`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/symbol_database.py#L54),
+[`SymbolDatabase.CreatePrototype`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/symbol_database.py#L60),
+and
+[`SymbolDatabase.GetMessages`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/symbol_database.py#L66)
+
+**Replacement:** `message_factory.GetMessageClass()` and
+`message_factory.GetMessageClassesForFiles()`.
+
+#### GetDebugString
+
+**APIs:**
+[`GetDebugString`](https://github.com/protocolbuffers/protobuf/blob/7f395af40e86e00b892e812beb67a03564884756/python/google/protobuf/pyext/descriptor.cc#L1510)
+
+**Replacement:**
+
+No replacement. It's only in Python C++ which is no longer released. It is not
+supported in pure Python or UPB.
+
+## Changes in Objective-C {#objc}
+
+**This will be the first breaking release for Objective-C**.
+
+Objective-C will bump its major version from 3.x.x to 4.30.x.
+
+### Overhaul Unknown Field Handling APIs Deprecating Most of the Existing APIs {#objc-field-handling}
+
+v30 will deprecate `GPBUnknownFieldSet` and replace it with `GPBUnknownFields`.
+The new type will preserve the ordering of unknown fields from the original
+input or API calls, to ensure any semantic meaning to the ordering is maintained
+when a message is written back out.
+
+As part of this, the `GPBUnknownField` type also has its APIs changed, with
+almost all of the existing APIs becoming deprecated and new ones added.
+
+Deprecated property APIs:
+
+*   `varintList`
+*   `fixed32List`
+*   `fixed64List`
+*   `lengthDelimitedList`
+*   `groupList`
+
+Deprecated modification APIs:
+
+*   `addVarint:`
+*   `addFixed32:`
+*   `addFixed64:`
+*   `addLengthDelimited:`
+*   `addGroup:`
+
+Deprecated initializer `initWithNumber:`.
+
+New property APIs:
+
+*   `type`
+*   `varint`
+*   `fixed32`
+*   `fixed64`
+*   `lengthDelimited`
+*   `group`
+
+This type will model a single field number in its value, rather than *grouping*
+all the values for a given field number. The APIs for creating new fields are
+the `add*` APIs on the `GPBUnknownFields` class.
+
+v30 will also deprecate `-[GPBMessage unknownFields]`. In its place, there will
+be new APIs to extract and update the unknown fields of the message.
+
+### Remove Deprecated APIs {#objc-remove-apis}
+
+v30 will remove the following public runtime APIs, which have been marked
+deprecated for at least one minor or major release and are obsolete or replaced.
+
+#### GPBFileDescriptor
+
+**API:**
+[-[`GPBFileDescriptor` syntax]](https://github.com/protocolbuffers/protobuf/blob/44bd65b2d3c0470d91a23cc14df5ffb1ab0af7cd/objectivec/GPBDescriptor.h#L118-L119)
+
+**Replacement:** Obsolete.
+
+#### GPBMessage mergeFrom:extensionRegistry
+
+**API:**
+[-[`GPBMessage mergeFrom:extensionRegistry:`]](https://github.com/protocolbuffers/protobuf/blob/44bd65b2d3c0470d91a23cc14df5ffb1ab0af7cd/objectivec/GPBMessage.h#L258-L261)
+
+**Replacement:**
+[-[`GPBMessage mergeFrom:extensionRegistry:error:`]](https://github.com/protocolbuffers/protobuf/blob/44bd65b2d3c0470d91a23cc14df5ffb1ab0af7cd/objectivec/GPBMessage.h#L275-L277)
+
+#### GPBDuration timeIntervalSince1970
+
+**API:**
+[-[`GPBDuration timeIntervalSince1970`]](https://github.com/protocolbuffers/protobuf/blob/29fca8a64b62491fb0a2ce61878e70eda88dde98/objectivec/GPBWellKnownTypes.h#L95-L100)
+
+**Replacement:**
+[-[`GPBDuration timeInterval`]](https://github.com/protocolbuffers/protobuf/blob/29fca8a64b62491fb0a2ce61878e70eda88dde98/objectivec/GPBWellKnownTypes.h#L74-L89)
+
+#### GPBTextFormatForUnknownFieldSet
+
+**API:**
+[`GPBTextFormatForUnknownFieldSet()`](https://github.com/protocolbuffers/protobuf/blob/29fca8a64b62491fb0a2ce61878e70eda88dde98/objectivec/GPBUtilities.h#L32-L43)
+
+**Replacement:** Obsolete - Use
+[`GPBTextFormatForMessage()`](https://github.com/protocolbuffers/protobuf/blob/29fca8a64b62491fb0a2ce61878e70eda88dde98/objectivec/GPBUtilities.h#L20-L30),
+which includes any unknown fields.
+
+#### GPBUnknownFieldSet
+
+**API:**
+[`GPBUnknownFieldSet`](https://github.com/protocolbuffers/protobuf/blob/224573d66a0cc958c76cb43d8b2eb3aa7cdb89f2/objectivec/GPBUnknownFieldSet.h)
+
+**Replacement:**
+[`GPBUnknownFields`](https://github.com/protocolbuffers/protobuf/blob/224573d66a0cc958c76cb43d8b2eb3aa7cdb89f2/objectivec/GPBUnknownFields.h)
+
+#### GPBMessage unknownFields
+
+**API:**
+[`GPBMessage unknownFields` property](https://github.com/protocolbuffers/protobuf/blob/224573d66a0cc958c76cb43d8b2eb3aa7cdb89f2/objectivec/GPBMessage.h#L73-L76)
+
+**Replacement:**
+[-[`GPBUnknownFields initFromMessage:`]](https://github.com/protocolbuffers/protobuf/blob/224573d66a0cc958c76cb43d8b2eb3aa7cdb89f2/objectivec/GPBUnknownFields.h#L30-L38),
+[-[`GPBMessage mergeUnknownFields:extensionRegistry:error:`]](https://github.com/protocolbuffers/protobuf/blob/f26bdff7cc0bb7e8ed88253ba16f81614a26cf16/objectivec/GPBMessage.h#L506-L528),
+and
+[-[`GPBMessage clearUnknownFields`]](https://github.com/protocolbuffers/protobuf/blob/224573d66a0cc958c76cb43d8b2eb3aa7cdb89f2/objectivec/GPBMessage.h#L497-L504C9)
+
+### Remove Deprecated Runtime APIs for Old Gencode {#objc-remove-apis-gencode}
+
+This release will remove deprecated runtime methods that support the Objective-C
+gencode from before the 3.22.x release. The library will also issue a log
+message at runtime when old generated code is starting up.
+
+**API:** [`+[GPBFileDescriptor
+allocDescriptorForClass:file:fields:fieldCount:storageSize:flags:]`](https://github.com/protocolbuffers/protobuf/blob/1b44ce0feef45a78ba99d09bd2e5ff5052a6541b/objectivec/GPBDescriptor_PackagePrivate.h#L213-L220)
+
+**Replacement:** Regenerate with a current version of the library.
+
+**API:** [`+[GPBFileDescriptor
+allocDescriptorForClass:rootClass:file:fields:fieldCount:storageSize:flags:]`](https://github.com/protocolbuffers/protobuf/blob/1b44ce0feef45a78ba99d09bd2e5ff5052a6541b/objectivec/GPBDescriptor_PackagePrivate.h#L221-L229)
+
+**Replacement:** Regenerate with a current version of the library.
+
+**API:** [`+[GPBEnumDescriptor
+allocDescriptorForName:valueNames:values:count:enumVerifier:]`](https://github.com/protocolbuffers/protobuf/blob/1b44ce0feef45a78ba99d09bd2e5ff5052a6541b/objectivec/GPBDescriptor_PackagePrivate.h#L285-L291)
+
+**Replacement:** Regenerate with a current version of the library.
+
+**API:** [`+[GPBEnumDescriptor
+allocDescriptorForName:valueNames:values:count:enumVerifier:extraTextFormatInfo:]`](https://github.com/protocolbuffers/protobuf/blob/1b44ce0feef45a78ba99d09bd2e5ff5052a6541b/objectivec/GPBDescriptor_PackagePrivate.h#L292-L299)
+
+**Replacement:** Regenerate with a current version of the library.
+
+**API:**
+[`-[GPBExtensionDescriptor initWithExtensionDescription:]`](https://github.com/protocolbuffers/protobuf/blob/1b44ce0feef45a78ba99d09bd2e5ff5052a6541b/objectivec/GPBDescriptor_PackagePrivate.h#L317-L320)
+
+**Replacement:** Regenerate with a current version of the library.
+
+## Other Changes {#non-breaking}
+
+In addition to those breaking changes are some other changes worth noting. While
+the following are not considered breaking changes, they may still impact users.
+
+### Poison Pill Warnings {#poison}
+
+v30 will update poison pills to emit warnings for old gencode + new runtime
+combinations that work under the new rolling upgrade policy, but will break in
+the *next* major bump. For example, Java 4.x.x gencode should work against 5.x.x
+runtime but warn of upcoming breakage against 6.x.x runtime.
+
+### Changes to UTF-8 Enforcement in C# and Ruby {#utf-8-enforcement}
+
+v30 will includes a fix to make UTF-8 enforcement consistent across languages.
+Users with bad non-UTF8 data in string fields may see surfaced UTF-8 enforcement
+errors earlier.

--- a/content/news/v30.md
+++ b/content/news/v30.md
@@ -10,7 +10,8 @@ The following announcements are specific to Version 30.x. For information
 presented chronologically, see [News](/news).
 
 The following sections cover planned breaking changes in the v30 release,
-expected in 2025 Q1. These describe changes as we anticipate them being
+expected in 2025 Q1. Also included are some changes that aren't breaking but may
+require action on your part. These describe changes as we anticipate them being
 implemented, but due to the flexible nature of software some of these changes
 may not land or may vary from how they are described in this topic.
 
@@ -84,8 +85,24 @@ This release will drop C++ 14 as the minimum supported version and raise it to
 17, as per the
 [Foundational C++ Support matrix](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md).
 
-Per [our policies](https://protobuf.dev/support/version-support/), we do not
+Per [our policies](https://protobuf.dev/support/version-support), we do not
 consider this to be a breaking change.
+
+## Introduce ASAN Poisoning After Clearing Oneof Messages on Arena
+
+This change adds a hardening check that affects C++ protobufs using Arenas.
+Oneof messages allocated on the protobuf arena will now be cleared in debug and
+poisoned in ASAN mode. After calling clear, future attempts to use the memory
+region will cause a crash in ASAN as a use-after-free error.
+
+This implementation requires C++17.
+
+## Dropping our C++ CocoaPods release
+
+In v30, we will be dropping our C++ CocoaPods release, which has been broken
+since v4.x.x. C++ users should use our
+[GitHub release](https://github.com/protocolbuffers/protobuf/releases) directly
+instead.
 
 ## Changes in JRuby {#jruby}
 
@@ -119,6 +136,15 @@ if you need a direct reference.
 Python's and upb's field setters will be fixed in v30 to validate closed enums
 under edition 2023. Closed enum fields updated with invalid values will generate
 errors.
+
+### Remove Deprecated py_proto_library Macro
+
+The deprecated internal `py_proto_library` Bazel macro in `protobuf.bzl` will be
+removed in v30.x.
+
+This should be replaced by the official `py_proto_library` which will be moved
+to protobuf in `bazel/py_proto_library` as of v29.x. This implementation was
+previously available in `rules_python` prior to v29.x.
 
 ### Remove Deprecated APIs {#python-remove-apis}
 
@@ -169,6 +195,31 @@ and
 
 No replacement. It's only in Python C++ which is no longer released. It is not
 supported in pure Python or UPB.
+
+### Python setdefault Behavior Change for Map Fields
+
+Starting in v30, `setdefault` will be similar to `dict` for `ScalarMap`, except
+that both key and value must be set. `setdefault` will be rejected for
+`MessageMaps`.
+
+## Python Nested Message Class \_\_qualname\_\_ Contains the Outer Message Name
+
+Python nested message class `__qualname__` now contains the outer message name.
+Prior to v30, `__qualname__` has the same result with `__name__` for nested
+message, in that the outer message name was not included.
+
+For example:
+
+```python
+message Foo {
+  message Bar {
+    bool bool_field = 1;
+  }
+}
+nested = test_pb2.Foo.Bar()
+self.assertEqual('Bar', nested.__class__.__name__)
+self.assertEqual('Foo.Bar', nested.__class__.__qualname__) # It was 'Bar' before
+```
 
 ## Changes in Objective-C {#objc}
 
@@ -324,3 +375,12 @@ runtime but warn of upcoming breakage against 6.x.x runtime.
 v30 will includes a fix to make UTF-8 enforcement consistent across languages.
 Users with bad non-UTF8 data in string fields may see surfaced UTF-8 enforcement
 errors earlier.
+
+## Ruby and PHP Errors in JSON Parsing
+
+v30 fixes non-conformance in JSON parsing of strings in numeric fields per the
+[JSON spec](https://protobuf.dev/programming-guides/json/).
+
+This fix will not be accompanied by a major version bump, but Ruby and PHP will
+now raise errors for non-numeric strings (e.g. "", "12abc", "abc") in numeric
+fields. v29.x will include a warning for these error cases.

--- a/content/programming-guides/proto-limits.md
+++ b/content/programming-guides/proto-limits.md
@@ -33,8 +33,9 @@ specs.
 
 ## Number of Values in an Enum {#enum}
 
-The lowest limit is ~1700 values, in Java (fix available
-go/java-large-enum-support). Other languages have different limits.
+The lowest limit is ~1700 values, in Java
+. Other languages have different
+limits.
 
 ## Total Size of the Message {#total}
 

--- a/content/reference/protobuf/edition-2023-spec.md
+++ b/content/reference/protobuf/edition-2023-spec.md
@@ -105,7 +105,7 @@ The edition statement replaces the legacy `syntax` keyword, and is used to
 define the edition that this file is using.
 
 ```
-edition = "edition" "=" ("'" decimalLit '"') ";"
+edition = "edition" "=" [ ( "'" decimalLit "'" ) | ( '"' decimalLit '"' ) ] ";"
 ```
 
 ## Import Statement {#import_statement}

--- a/content/reference/protobuf/google.protobuf.md
+++ b/content/reference/protobuf/google.protobuf.md
@@ -39,6 +39,19 @@ type = "docs"
 -   [`UInt64Value`](#uint64-value) (message)
 -   [`Value`](#value) (message)
 
+Well-Known Types that end in "`Value`" are wrapper messages for other types,
+such as `BoolValue` and `EnumValue`. These are now obsolete. The only reasons to
+use wrappers today would be:
+
+*   Wire compatibility with messages that already use them.
+*   If you want to put a scalar value into an `Any` message.
+
+In most cases, there are better options:
+
+*   For new messages, it's better to use regular explicit-presence fields
+    (`optional` in proto2/proto3, regular field in edition >= 2023).
+*   Extensions are generally a better option than `Any` fields.
+
 ## Any {#any}
 
 `Any` contains an arbitrary serialized message along with a URL that describes

--- a/content/reference/rust/building-rust-protos.md
+++ b/content/reference/rust/building-rust-protos.md
@@ -1,6 +1,6 @@
 +++
 title = "Building Rust Protos"
-weight = 783
+weight = 784
 linkTitle = "Building Rust Protos"
 description = "Describes using Blaze to build Rust protos."
 type = "docs"

--- a/content/reference/rust/rust-design-decisions.md
+++ b/content/reference/rust/rust-design-decisions.md
@@ -1,6 +1,6 @@
 +++
 title = "Rust Proto Design Decisions"
-weight = 782
+weight = 785
 linkTitle = "Design Decisions"
 description = "Explains some of the design choices that the Rust Proto implementation makes."
 type = "docs"
@@ -23,7 +23,7 @@ implemented on top of existing protobuf implementations, or as we call these
 implementations: kernels.
 
 The biggest factor that goes into this decision was to enable zero-cost of
-adding Rust to a preexisting binary which already uses non-Rust Protobuf. Bby
+adding Rust to a preexisting binary which already uses non-Rust Protobuf. By
 enabling the implementation to be ABI-compatible with the C++ Protobuf generated
 code, it is possible to share Protobuf messages across the language boundary
 (FFI) as plain pointers, avoiding the need to serialize in one language, pass

--- a/content/reference/rust/rust-redaction.md
+++ b/content/reference/rust/rust-redaction.md
@@ -1,6 +1,6 @@
 +++
 title = "Redaction in Rust"
-weight = 785
+weight = 783
 linkTitle = "Redaction in Rust"
 description = "Describes redaction in Rust."
 type = "docs"

--- a/content/support/version-support.md
+++ b/content/support/version-support.md
@@ -8,6 +8,9 @@ type = "docs"
 
 <link rel="stylesheet" href="/includes/version-tables.css">
 
+<!-- version-chart: quarter to highlight as latest release -->
+<!--#set var="y24q3" value="latest-release"-->
+
 Support windows for protoc and the various languages are covered in the tables
 later in this topic. Version numbers throughout this topic use
 [SemVer](https://semver.org) conventions; in the version "3.21.7," we say that
@@ -93,241 +96,154 @@ In general:
 The most recent release is always supported. Support for earlier minor versions
 ends when a new minor version under the same major version is released. Support
 for earlier major versions ends four quarters beyond the quarter that the
-breaking release is introduced. For example, when Python 4.21.0 was released in
-May of 2022, that set the end of public support of Python 3.20.1 at the
-[end of 2023 Q2](#python).
+breaking release is introduced. For example, when Protobuf Python 5.26.0 was
+released in Q1 of 2024, that set the end of support of Protobuf Python 4.25.x at
+the [end of Q1 2025](#python).
 
 The following sections provide a guide to the support for each language.
 
 ## C++ {#cpp}
 
-This table provides specific dates for support duration.
-
-<table>
-  <tr>
-    <th>Branch</th>
-    <th>Initial Release</th>
-    <th>Public Support Until</th>
-  </tr>
-  <tr>
-    <td class="gray">3.21.x</td>
-    <td class="gray">25 May 2022</td>
-    <td class="gray"><s>31 Mar 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.22.x</td>
-    <td class="gray">16 Feb 2023</td>
-    <td class="gray"><s>8 May 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.23.x</td>
-    <td class="gray">8 May 2023</td>
-    <td class="gray"><s>8 Aug 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.24.x</td>
-    <td class="gray">8 Aug 2023</td>
-    <td class="gray"><s>1 Nov 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.25.x</td>
-    <td>1 Nov 2023</td>
-    <td>31 Mar 2025</td>
-  </tr>
-  <tr>
-    <td class="gray">5.26.x</td>
-    <td class="gray">13 Mar 2024</td>
-    <td class="gray"><s>23 May 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">5.27.x</td>
-    <td class="gray">23 May 2024</td>
-    <td class="gray"><s>28 Aug 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">5.28.x</td>
-    <td>28 Aug 2024</td>
-    <td>TBD</td>
-  </tr>
-</table>
-
-This table graphically shows support durations.
-
 C++ will target making major version bumps annually in Q1 of each year.
 
-<table>
+The protoc version can be inferred from the Protobuf C++ minor version number.
+Example: Protobuf C++ version 4.25.x uses protoc version 25.x.
+
+Future plans are shown in *italics* and are subject to change.
+
+**Release support dates**
+
+<table class="version-table">
   <tr>
-    <th>protoc</th>
-    <th>C++</th>
-    <th>23Q1</th>
-    <th>23Q2</th>
-    <th>23Q3</th>
-    <th>23Q4</th>
-    <th>24Q1</th>
-    <th>24Q2</th>
-    <th>24Q3</th>
-    <th>24Q4</th>
-    <th>25Q1</th>
+    <th>Protobuf C++</th>
+    <th>Release date</th>
+    <th>End of support</th>
   </tr>
-  <tr>
-    <td class="gray">21.x</td>
-    <td class="gray">3.21.x</td>
-    <td title=23Q1 class="green">PS</td>
-    <td title=23Q2 class="green">PS</td>
-    <td title=23Q3 class="green">PS</td>
-    <td title=23Q4 class="green">PS</td>
-    <td title=24Q1 class="red">SE</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="end-of-life">
+    <th>3.x</th>
+    <td>25 May 2022</td>
+    <td>31 Mar 2024</td>
   </tr>
-  <tr>
-    <td class="gray">22.x</td>
-    <td class="gray">4.22.x</td>
-    <td title=23Q1 class="blue">IR</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="maintenance">
+    <th>4.x</th>
+    <td>16 Feb 2023</td>
+    <td>31 Mar 2025</td>
   </tr>
-  <tr>
-    <td class="gray">23.x</td>
-    <td class="gray">4.23.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2 class="blue">IR</td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=22Q2></td>
-    <td title=22Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="active">
+    <th>5.x</th>
+    <td>13 Mar 2024</td>
+    <td>31 Mar 2026</td>
   </tr>
-  <tr>
-    <td class="gray">24.x</td>
-    <td class="gray">4.24.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">25.x</td>
-    <td class="gray">4.25.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1 class="green">PS</td>
-    <td title=24Q2 class="green">PS</td>
-    <td title=24Q3 class="green">PS</td>
-    <td title=24Q4 class="green">PS</td>
-    <td title=25Q1 class="red">SE</td>
-  </tr>
-  <tr>
-    <td class="gray">26.x</td>
-    <td class="gray">5.26.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1 class="blue">IR</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">27.x</td>
-    <td class="gray">5.27.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2 class="blue">IR</td>
-    <td title=24Q3></td>
-    <td title=24Q4</td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">28.x</td>
-    <td class="gray">5.28.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3 class="blue">IR</td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td colspan="13">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
-  </tr>
-  <tr>
-    <td class="gray">29.x</td>
-    <td class="gray">5.29.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4 class="blue">IR</td>
-    <td title=25Q1 class="green">PS</td>
-  </tr>
-  <tr>
-    <td class="gray">30.x</td>
-    <td class="gray">6.30.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1 class="blue">IR</td>
+  <tr class="future">
+    <th>6.x</th>
+    <td>Q1 2025</td>
+    <td>31 Mar 2027</td>
   </tr>
 </table>
 
-<table>
+**Release support chart**
+
+<table class="version-chart">
   <tr>
-    <td class="gray">
-      <b>Legend</b>
-    </td>
+    <th>Protobuf C++</th>
+    <th>protoc</th>
+    <th class="<!--#echo var="y23q1"-->"><span>23Q1</span></th>
+    <th class="<!--#echo var="y23q2"-->"><span>23Q2</span></th>
+    <th class="<!--#echo var="y23q3"-->"><span>23Q3</span></th>
+    <th class="<!--#echo var="y23q4"-->"><span>23Q4</span></th>
+    <th class="<!--#echo var="y24q1"-->"><span>24Q1</span></th>
+    <th class="<!--#echo var="y24q2"-->"><span>24Q2</span></th>
+    <th class="<!--#echo var="y24q3"-->"><span>24Q3</span></th>
+    <th class="<!--#echo var="y24q4"-->"><span>24Q4</span></th>
+    <th class="<!--#echo var="y25q1"-->"><span>25Q1</span></th>
+    <th class="<!--#echo var="y25q2"-->"><span>25Q2</span></th>
+    <th class="<!--#echo var="y25q3"-->"><span>25Q3</span></th>
+    <th class="<!--#echo var="y25q4"-->"><span>25Q4</span></th>
   </tr>
-  <tr>
-    <td class="blue">
-      Initial release (IR)
-    </td>
+  <tr class="end-of-life">
+    <th>3.x</th>
+    <td>21.x</td>
+    <td class="<!--#echo var="y23q1"--> maintenance">3.21</td>
+    <td class="<!--#echo var="y23q2"--> maintenance">3.21</td>
+    <td class="<!--#echo var="y23q3"--> maintenance">3.21</td>
+    <td class="<!--#echo var="y23q4"--> maintenance">3.21</td>
+    <td class="<!--#echo var="y24q1"--> maintenance">3.21</td>
+    <td class="<!--#echo var="y24q2"-->"></td>
+    <td class="<!--#echo var="y24q3"-->"></td>
+    <td class="<!--#echo var="y24q4"-->"></td>
+    <td class="<!--#echo var="y25q1"-->"></td>
+    <td class="<!--#echo var="y25q2"-->"></td>
+    <td class="<!--#echo var="y25q3"-->"></td>
+    <td class="<!--#echo var="y25q4"-->"></td>
   </tr>
-  <tr>
-    <td class="green">
-      Public support (PS)
-    </td>
+  <tr class="maintenance">
+    <th>4.x</th>
+    <td>22.x-25.x</td>
+    <td class="<!--#echo var="y23q1"--> active">4.22</td>
+    <td class="<!--#echo var="y23q2"--> active">4.23</td>
+    <td class="<!--#echo var="y23q3"--> active">4.24</td>
+    <td class="<!--#echo var="y23q4"--> active">4.25</td>
+    <td class="<!--#echo var="y24q1"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y24q2"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y24q3"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y24q4"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y25q2"-->"></td>
+    <td class="<!--#echo var="y25q3"-->"></td>
+    <td class="<!--#echo var="y25q4"-->"></td>
   </tr>
-  <tr>
-    <td class="red">
-      Support ends (SE)
-    </td>
+  <tr class="active">
+    <th>5.x</th>
+    <td>26.x-29.x</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"--> active">5.26</td>
+    <td class="<!--#echo var="y24q2"--> active">5.27</td>
+    <td class="<!--#echo var="y24q3"--> active">5.28</td>
+    <td class="<!--#echo var="y24q4"--> active">5.29</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">5.29</td>
+    <td class="<!--#echo var="y25q2"--> maintenance">5.29</td>
+    <td class="<!--#echo var="y25q3"--> maintenance">5.29</td>
+    <td class="<!--#echo var="y25q4"--> maintenance">5.29</td>
+  </tr>
+  <tr class="future">
+    <th>6.x</th>
+    <td>30.x-33.x</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"-->"></td>
+    <td class="<!--#echo var="y24q2"-->"></td>
+    <td class="<!--#echo var="y24q3"-->"></td>
+    <td class="<!--#echo var="y24q4"-->"></td>
+    <td class="<!--#echo var="y25q1"--> active">6.30</td>
+    <td class="<!--#echo var="y25q2"--> active">6.31</td>
+    <td class="<!--#echo var="y25q3"--> active">6.32</td>
+    <td class="<!--#echo var="y25q4"--> active">6.33</td>
+  </tr>
+</table>
+
+**Legend**
+
+<table class="legend">
+  <tr class="active">
+    <th>Active</th>
+    <td>Minor and patch releases with new features, compatible changes and bug fixes.</td>
+  </tr>
+  <tr class="maintenance">
+    <th>Maintenance</th>
+    <td>Patch releases with critical bug fixes.</td>
+  </tr>
+  <tr class="end-of-life">
+    <th>End of life</th>
+    <td>Release is unsupported. Users should upgrade to a supported release.</td>
+  </tr>
+  <tr class="future">
+    <th>Future</th>
+    <td>Projected release. Shown for planning purposes.</td>
   </tr>
 </table>
 
@@ -341,213 +257,81 @@ For specific versions supported, see
 
 ## C&#35; {#csharp}
 
-This table provides specific dates for support duration.
+The protoc version can be inferred from the Protobuf C# minor version number.
+Example: Protobuf C# version 3.25.x uses protoc version 25.x.
 
-<table>
+Future plans are shown in *italics* and are subject to change.
+
+**Release support dates**
+
+<table class="version-table">
   <tr>
-    <th>Branch</th>
-    <th>Initial Release</th>
-    <th>Public Support Until</th>
+    <th>Protobuf C#</th>
+    <th>Release date</th>
+    <th>End of support</th>
   </tr>
-  <tr>
-    <td class="gray">3.22.x</td>
-    <td class="gray">16 Feb 2023</td>
-    <td class="gray"><s>8 May 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.23.x</td>
-    <td class="gray">8 May 2023</td>
-    <td class="gray"><s>8 Aug 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.24.x</td>
-    <td class="gray">8 Aug 2023</td>
-    <td class="gray"><s>1 Nov 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.25.x</td>
-    <td class="gray">1 Nov 2023</td>
-    <td class="gray"><s>13 Mar 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.26.x</td>
-    <td class="gray">13 Mar 2024</td>
-    <td class="gray"><s>23 May 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.27.x</td>
-    <td class="gray">23 May 2024</td>
-    <td class="gray"><s>28 Aug 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.28.x</td>
-    <td>28 Aug 2024</td>
+  <tr class="active">
+    <th>3.x</th>
+    <td>16 Feb 2023</td>
     <td>TBD</td>
   </tr>
 </table>
 
-This table graphically shows support durations.
+**Release support chart**
 
-<table>
+<table class="version-chart">
   <tr>
+    <th>Protobuf C#</th>
     <th>protoc</th>
-    <th>C#</th>
-    <th>23Q1</th>
-    <th>23Q2</th>
-    <th>23Q3</th>
-    <th>23Q4</th>
-    <th>24Q1</th>
-    <th>24Q2</th>
-    <th>24Q3</th>
-    <th>24Q4</th>
-    <th>25Q1</th>
+    <th class="<!--#echo var="y23q1"-->"><span>23Q1</span></th>
+    <th class="<!--#echo var="y23q2"-->"><span>23Q2</span></th>
+    <th class="<!--#echo var="y23q3"-->"><span>23Q3</span></th>
+    <th class="<!--#echo var="y23q4"-->"><span>23Q4</span></th>
+    <th class="<!--#echo var="y24q1"-->"><span>24Q1</span></th>
+    <th class="<!--#echo var="y24q2"-->"><span>24Q2</span></th>
+    <th class="<!--#echo var="y24q3"-->"><span>24Q3</span></th>
+    <th class="<!--#echo var="y24q4"-->"><span>24Q4</span></th>
+    <th class="<!--#echo var="y25q1"-->"><span>25Q1</span></th>
+    <th class="<!--#echo var="y25q2"-->"><span>25Q2</span></th>
+    <th class="<!--#echo var="y25q3"-->"><span>25Q3</span></th>
+    <th class="<!--#echo var="y25q4"-->"><span>25Q4</span></th>
   </tr>
-  <tr>
-    <td class="gray">22.x</td>
-    <td class="gray">3.22.x</td>
-    <td title=23Q1 class="blue">IR</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">23.x</td>
-    <td class="gray">3.23.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2 class="blue">IR</td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">24.x</td>
-    <td class="gray">3.24.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">25.x</td>
-    <td class="gray">3.25.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">26.x</td>
-    <td class="gray">3.26.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1 class="blue">IR</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">27.x</td>
-    <td class="gray">3.27.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2 class="blue">IR</td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">28.x</td>
-    <td class="gray">3.28.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3 class="blue">IR</td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td colspan="12">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
-  </tr>
-  <tr>
-    <td class="gray">29.x</td>
-    <td class="gray"></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4 class="blue">IR</td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">30.x</td>
-    <td class="gray"></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1 class="blue">IR</td>
+  <tr class="active">
+    <th>3.x</th>
+    <td>22.x-33.x</td>
+    <td class="<!--#echo var="y23q1"--> active">3.22</td>
+    <td class="<!--#echo var="y23q2"--> active">3.23</td>
+    <td class="<!--#echo var="y23q3"--> active">3.24</td>
+    <td class="<!--#echo var="y23q4"--> active">3.25</td>
+    <td class="<!--#echo var="y24q1"--> active">3.26</td>
+    <td class="<!--#echo var="y24q2"--> active">3.27</td>
+    <td class="<!--#echo var="y24q3"--> active">3.28</td>
+    <td class="<!--#echo var="y24q4"--> active">3.29</td>
+    <td class="<!--#echo var="y25q1"--> active">3.30</td>
+    <td class="<!--#echo var="y25q2"--> active">3.31</td>
+    <td class="<!--#echo var="y25q3"--> active">3.32</td>
+    <td class="<!--#echo var="y25q4"--> active">3.33</td>
   </tr>
 </table>
 
-<table>
-  <tr>
-    <td class="gray">
-      <b>Legend</b>
-    </td>
+**Legend**
+
+<table class="legend">
+  <tr class="active">
+    <th>Active</th>
+    <td>Minor and patch releases with new features, compatible changes and bug fixes.</td>
   </tr>
-  <tr>
-    <td class="blue">
-      Initial release (IR)
-    </td>
+  <tr class="maintenance">
+    <th>Maintenance</th>
+    <td>Patch releases with critical bug fixes.</td>
   </tr>
-  <tr>
-    <td class="green">
-      Public support (PS)
-    </td>
+  <tr class="end-of-life">
+    <th>End of life</th>
+    <td>Release is unsupported. Users should upgrade to a supported release.</td>
   </tr>
-  <tr>
-    <td class="red">
-      Support ends (SE)
-    </td>
+  <tr class="future">
+    <th>Future</th>
+    <td>Projected release. Shown for planning purposes.</td>
   </tr>
 </table>
 
@@ -561,227 +345,117 @@ For specific versions supported, see
 
 ## Java {#java}
 
-This table provides specific dates for support duration.
-
-<table>
-  <tr>
-    <th>Branch</th>
-    <th>Initial Release</th>
-    <th>Public Support Until</th>
-  </tr>
-  <tr>
-    <td class="gray">3.19.x</td>
-    <td class="gray">20 Oct 2021</td>
-    <td class="gray"><s>25 Mar 2022</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.20.x</td>
-    <td class="gray">25 Mar 2022</td>
-    <td class="gray"><s>25 May 2022</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.21.x</td>
-    <td class="gray">25 May 2022</td>
-    <td class="gray"><s>16 Feb 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.22.x</td>
-    <td class="gray">16 Feb 2023</td>
-    <td class="gray"><s>8 May 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.23.x</td>
-    <td class="gray">8 May 2023</td>
-    <td class="gray"><s>8 Aug 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.24.x</td>
-    <td class="gray">8 Aug 2023</td>
-    <td class="gray"><s>1 Nov 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.25.x</td>
-    <td>1 Nov 2023</td>
-    <td>31 Mar 2026*</td>
-  </tr>
-  <tr>
-    <td class="gray">4.26.x</td>
-    <td class="gray">13 Mar 2024</td>
-    <td class="gray"><s>23 May 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.27.x</td>
-    <td class="gray">23 May 2024</td>
-    <td class="gray"><s>28 Aug 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.28.x</td>
-    <td>28 Aug 2024</td>
-    <td>TBD</td>
-  </tr>
-</table>
-
-**NOTE:** The support window for the Java 3.25.x release will be 24 months
-rather than the typical 12 months for the final release in a major version line.
-Future major version updates (5.x+) will adopt an improved
-["rolling compatibility window"](/support/cross-version-runtime-guarantee/#major)
-that should allow a return to 12-month support windows.
-
-This table graphically shows support durations.
-
 Java will target making major version bumps annually in Q1 of each year.
 
-<table>
+The protoc version can be inferred from the Protobuf Java minor version number.
+Example: Protobuf Java version 3.25.x uses protoc version 25.x.
+
+Future plans are shown in *italics* and are subject to change.
+
+**Release support dates**
+
+<table class="version-table">
   <tr>
-    <th>protoc</th>
-    <th>Java</th>
-    <th>23Q2</th>
-    <th>23Q3</th>
-    <th>23Q4</th>
-    <th>24Q1</th>
-    <th>24Q2</th>
-    <th>24Q3</th>
-    <th>24Q4</th>
-    <th>25Q1</th>
+    <th>Protobuf Java</th>
+    <th>Release date</th>
+    <th>End of support</th>
   </tr>
-  <tr>
-    <td class="gray">22.x</td>
-    <td class="gray">3.22.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="maintenance">
+    <th>3.x</th>
+    <td>16 Feb 2023</td>
+    <td>31 Mar 2026*</td>
   </tr>
-  <tr>
-    <td class="gray">23.x</td>
-    <td class="gray">3.23.x</td>
-    <td title=23Q2 class="blue">IR</td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="active">
+    <th>4.x</th>
+    <td>13 Mar 2024</td>
+    <td>31 Mar 2027</td>
   </tr>
-  <tr>
-    <td class="gray">24.x</td>
-    <td class="gray">3.24.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">25.x</td>
-    <td class="gray">3.25.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-<!--3.25.x is special and will be publicly supported until end of 26Q1-->
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1 class="green">PS</td>
-    <td title=24Q2 class="green">PS</td>
-    <td title=24Q3 class="green">PS</td>
-    <td title=24Q4 class="green">PS</td>
-    <td title=25Q1 class="green">PS</td>
-  </tr>
-  <tr>
-    <td class="gray">26.x</td>
-    <td class="gray">4.26.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1 class="blue">IR</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">27.x</td>
-    <td class="gray">4.27.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2 class="blue">IR</td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">28.x</td>
-    <td class="gray">4.28.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3 class="blue">IR</td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td colspan="12">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
-  </tr>
-  <tr>
-    <td class="gray">29.x</td>
-    <td class="gray">4.29.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4 class="blue">IR</td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">30.x</td>
-    <td class="gray">4.30.x</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1 class="blue">IR</td>
+  <tr class="future">
+    <th>5.x</th>
+    <td>Q1 2026*</td>
+    <td>31 Mar 2028</td>
   </tr>
 </table>
 
-<table>
+**NOTE:** The maintenance support window for the Protobuf Java 3.x release will
+be 24 months rather than the typical 12 months for the final release in a major
+version line. Future major version updates (5.x, planned for Q1 2026) will adopt
+an improved
+["rolling compatibility window"](/support/cross-version-runtime-guarantee/#major)
+that should allow a return to 12-month support windows. There will be no major
+version bump in Q1 2025.
+
+**Release support chart**
+
+<table class="version-chart">
   <tr>
-    <td class="gray">
-      <b>Legend</b>
-    </td>
+    <th>Protobuf Java</th>
+    <th>protoc</th>
+    <th class="<!--#echo var="y23q1"-->"><span>23Q1</span></th>
+    <th class="<!--#echo var="y23q2"-->"><span>23Q2</span></th>
+    <th class="<!--#echo var="y23q3"-->"><span>23Q3</span></th>
+    <th class="<!--#echo var="y23q4"-->"><span>23Q4</span></th>
+    <th class="<!--#echo var="y24q1"-->"><span>24Q1</span></th>
+    <th class="<!--#echo var="y24q2"-->"><span>24Q2</span></th>
+    <th class="<!--#echo var="y24q3"-->"><span>24Q3</span></th>
+    <th class="<!--#echo var="y24q4"-->"><span>24Q4</span></th>
+    <th class="<!--#echo var="y25q1"-->"><span>25Q1</span></th>
+    <th class="<!--#echo var="y25q2"-->"><span>25Q2</span></th>
+    <th class="<!--#echo var="y25q3"-->"><span>25Q3</span></th>
+    <th class="<!--#echo var="y25q4"-->"><span>25Q4</span></th>
   </tr>
-  <tr>
-    <td class="blue">
-      Initial release (IR)
-    </td>
+  <tr class="maintenance">
+    <th>3.x</th>
+    <td>22.x-25.x</td>
+    <td class="<!--#echo var="y23q1"--> active">3.22</td>
+    <td class="<!--#echo var="y23q2"--> active">3.23</td>
+    <td class="<!--#echo var="y23q3"--> active">3.24</td>
+    <td class="<!--#echo var="y23q4"--> active">3.25</td>
+    <td class="<!--#echo var="y24q1"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q2"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q3"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q4"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q2"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q3"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q4"--> maintenance">3.25</td>
   </tr>
-  <tr>
-    <td class="green">
-      Public support (PS)
-    </td>
+  <tr class="active">
+    <th>4.x</th>
+    <td>26.x-33.x</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"--> active">4.26</td>
+    <td class="<!--#echo var="y24q2"--> active">4.27</td>
+    <td class="<!--#echo var="y24q3"--> active">4.28</td>
+    <td class="<!--#echo var="y24q4"--> active">4.29</td>
+    <td class="<!--#echo var="y25q1"--> active">4.30</td>
+    <td class="<!--#echo var="y25q2"--> active">4.31</td>
+    <td class="<!--#echo var="y25q3"--> active">4.32</td>
+    <td class="<!--#echo var="y25q4"--> active">4.33</td>
   </tr>
-  <tr>
-    <td class="red">
-      Support ends (SE)
-    </td>
+</table>
+
+**Legend**
+
+<table class="legend">
+  <tr class="active">
+    <th>Active</th>
+    <td>Minor and patch releases with new features, compatible changes and bug fixes.</td>
+  </tr>
+  <tr class="maintenance">
+    <th>Maintenance</th>
+    <td>Patch releases with critical bug fixes.</td>
+  </tr>
+  <tr class="end-of-life">
+    <th>End of life</th>
+    <td>Release is unsupported. Users should upgrade to a supported release.</td>
+  </tr>
+  <tr class="future">
+    <th>Future</th>
+    <td>Projected release. Shown for planning purposes.</td>
   </tr>
 </table>
 
@@ -795,425 +469,203 @@ For specific versions supported, see
 
 ## Objective-C {#objc}
 
-This table provides specific dates for support duration.
+The protoc version can be inferred from the Protobuf Objective-C minor version
+number. Example: Protobuf Objective-C version 3.25.x uses protoc version 25.x.
 
-<table>
+Future plans are shown in *italics* and are subject to change.
+
+**Release support dates**
+
+<table class="version-table">
   <tr>
-    <th>Branch</th>
-    <th>Initial Release</th>
-    <th>Public Support Until</th>
+    <th>Protobuf Objective-C</th>
+    <th>Release date</th>
+    <th>End of support</th>
   </tr>
-  <tr>
-    <td class="gray">3.22.x</td>
-    <td class="gray">16 Feb 2023</td>
-    <td class="gray"><s>8 May 2023</s></td>
+  <tr class="active">
+    <th>3.x</th>
+    <td>16 Feb 2023</td>
+    <td>31 Mar 2026</td>
   </tr>
-  <tr>
-    <td class="gray">3.23.x</td>
-    <td class="gray">8 May 2023</td>
-    <td class="gray"><s>8 Aug 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.24.x</td>
-    <td class="gray">8 Aug 2023</td>
-    <td class="gray"><s>1 Nov 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.25.x</td>
-    <td class="gray">1 Nov 2023</td>
-    <td class="gray"><s>13 Mar 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.26.x</td>
-    <td class="gray">13 Mar 2024</td>
-    <td class="gray"><s>23 May 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.27.x</td>
-    <td class="gray">23 May 2024</td>
-    <td class="gray"><s>28 Aug 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.28.x</td>
-    <td>28 Aug 2024</td>
+  <tr class="future">
+    <th>4.x</th>
+    <td>Q1 2025</td>
     <td>TBD</td>
   </tr>
 </table>
 
-This table graphically shows support durations.
+**Release support chart**
 
-<table>
+<table class="version-chart">
   <tr>
+    <th>Protobuf Objective-C</th>
     <th>protoc</th>
-    <th>ObjC</th>
-    <th>23Q1</th>
-    <th>23Q2</th>
-    <th>23Q3</th>
-    <th>23Q4</th>
-    <th>24Q1</th>
-    <th>24Q2</th>
-    <th>24Q3</th>
-    <th>24Q4</th>
-    <th>25Q1</th>
+    <th class="<!--#echo var="y23q1"-->"><span>23Q1</span></th>
+    <th class="<!--#echo var="y23q2"-->"><span>23Q2</span></th>
+    <th class="<!--#echo var="y23q3"-->"><span>23Q3</span></th>
+    <th class="<!--#echo var="y23q4"-->"><span>23Q4</span></th>
+    <th class="<!--#echo var="y24q1"-->"><span>24Q1</span></th>
+    <th class="<!--#echo var="y24q2"-->"><span>24Q2</span></th>
+    <th class="<!--#echo var="y24q3"-->"><span>24Q3</span></th>
+    <th class="<!--#echo var="y24q4"-->"><span>24Q4</span></th>
+    <th class="<!--#echo var="y25q1"-->"><span>25Q1</span></th>
+    <th class="<!--#echo var="y25q2"-->"><span>25Q2</span></th>
+    <th class="<!--#echo var="y25q3"-->"><span>25Q3</span></th>
+    <th class="<!--#echo var="y25q4"-->"><span>25Q4</span></th>
   </tr>
-  <tr>
-    <td class="gray">22.x</td>
-    <td class="gray">3.22.x</td>
-    <td title=23Q1 class="blue">IR</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="active">
+    <th>3.x</th>
+    <td>22.x-29.x</td>
+    <td class="<!--#echo var="y23q1"--> active">3.22</td>
+    <td class="<!--#echo var="y23q2"--> active">3.23</td>
+    <td class="<!--#echo var="y23q3"--> active">3.24</td>
+    <td class="<!--#echo var="y23q4"--> active">3.25</td>
+    <td class="<!--#echo var="y24q1"--> active">3.26</td>
+    <td class="<!--#echo var="y24q2"--> active">3.27</td>
+    <td class="<!--#echo var="y24q3"--> active">3.28</td>
+    <td class="<!--#echo var="y24q4"--> active">3.29</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">3.29</td>
+    <td class="<!--#echo var="y25q2"--> maintenance">3.29</td>
+    <td class="<!--#echo var="y25q3"--> maintenance">3.29</td>
+    <td class="<!--#echo var="y25q4"--> maintenance">3.29</td>
   </tr>
-  <tr>
-    <td class="gray">23.x</td>
-    <td class="gray">3.23.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2 class="blue">IR</td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">24.x</td>
-    <td class="gray">3.24.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">25.x</td>
-    <td class="gray">3.25.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">26.x</td>
-    <td class="gray">3.26.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1 class="blue">IR</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">27.x</td>
-    <td class="gray">3.27.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2 class="blue">IR</td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">28.x</td>
-    <td class="gray">3.28.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3 class="blue">IR</td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td colspan="12">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
-  </tr>
-  <tr>
-    <td class="gray">29.x</td>
-    <td class="gray">3.29.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4 class="blue">IR</td>
-    <td title=25Q1 class="green">PS</td>
-  </tr>
-  <tr>
-    <td class="gray">30.x</td>
-    <td class="gray">4.30.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1 class="blue">IR</td>
+  <tr class="future">
+    <th>4.x</th>
+    <td>30.x+</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"-->"></td>
+    <td class="<!--#echo var="y24q2"-->"></td>
+    <td class="<!--#echo var="y24q3"-->"></td>
+    <td class="<!--#echo var="y24q4"-->"></td>
+    <td class="<!--#echo var="y25q1"--> active">4.30</td>
+    <td class="<!--#echo var="y25q2"--> active">4.31</td>
+    <td class="<!--#echo var="y25q3"--> active">4.32</td>
+    <td class="<!--#echo var="y25q4"--> active">4.33</td>
   </tr>
 </table>
 
-<table>
-  <tr>
-    <td class="gray">
-      <b>Legend</b>
-    </td>
+**Legend**
+
+<table class="legend">
+  <tr class="active">
+    <th>Active</th>
+    <td>Minor and patch releases with new features, compatible changes and bug fixes.</td>
   </tr>
-  <tr>
-    <td class="blue">
-      Initial release (IR)
-    </td>
+  <tr class="maintenance">
+    <th>Maintenance</th>
+    <td>Patch releases with critical bug fixes.</td>
   </tr>
-  <tr>
-    <td class="green">
-      Public support (PS)
-    </td>
+  <tr class="end-of-life">
+    <th>End of life</th>
+    <td>Release is unsupported. Users should upgrade to a supported release.</td>
   </tr>
-  <tr>
-    <td class="red">
-      Support ends (SE)
-    </td>
+  <tr class="future">
+    <th>Future</th>
+    <td>Projected release. Shown for planning purposes.</td>
   </tr>
 </table>
 
 ## PHP {#php}
 
-This table provides specific dates for support duration.
+The protoc version can be inferred from the Protobuf PHP minor version number.
+Example: Protobuf PHP version 3.25.x uses protoc version 25.x.
 
-<table>
+Future plans are shown in *italics* and are subject to change.
+
+**Release support dates**
+
+<table class="version-table">
   <tr>
-    <th>Branch</th>
-    <th>Initial Release</th>
-    <th>Public Support Until</th>
+    <th>Protobuf PHP</th>
+    <th>Release date</th>
+    <th>End of support</th>
   </tr>
-  <tr>
-    <td class="gray">3.22.x</td>
-    <td class="gray">16 Feb 2023</td>
-    <td class="gray"><s>8 May 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.23.x</td>
-    <td class="gray">8 May 2023</td>
-    <td class="gray"><s>8 Aug 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.24.x</td>
-    <td class="gray">8 Aug 2023</td>
-    <td class="gray"><s>1 Nov 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.25.x</td>
-    <td>1 Nov 2023</td>
+  <tr class="maintenance">
+    <th>3.x</th>
+    <td>16 Feb 2023</td>
     <td>31 Mar 2025</td>
   </tr>
-  <tr>
-    <td class="gray">4.26.x</td>
-    <td class="gray">13 Mar 2024</td>
-    <td class="gray"><s>23 May 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.27.x</td>
-    <td class="gray">23 May 2024</td>
-    <td class="gray"><s>28 Aug 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.28.x</td>
-    <td>28 Aug 2024</td>
+  <tr class="active">
+    <th>4.x</th>
+    <td>13 Mar 2024</td>
     <td>TBD</td>
   </tr>
 </table>
 
-This table graphically shows support durations.
+**Release support chart**
 
-<table>
+<table class="version-chart">
   <tr>
+    <th>Protobuf PHP</th>
     <th>protoc</th>
-    <th>PHP</th>
-    <th>23Q1</th>
-    <th>23Q2</th>
-    <th>23Q3</th>
-    <th>23Q4</th>
-    <th>24Q1</th>
-    <th>24Q2</th>
-    <th>24Q3</th>
-    <th>24Q4</th>
-    <th>25Q1</th>
+    <th class="<!--#echo var="y23q1"-->"><span>23Q1</span></th>
+    <th class="<!--#echo var="y23q2"-->"><span>23Q2</span></th>
+    <th class="<!--#echo var="y23q3"-->"><span>23Q3</span></th>
+    <th class="<!--#echo var="y23q4"-->"><span>23Q4</span></th>
+    <th class="<!--#echo var="y24q1"-->"><span>24Q1</span></th>
+    <th class="<!--#echo var="y24q2"-->"><span>24Q2</span></th>
+    <th class="<!--#echo var="y24q3"-->"><span>24Q3</span></th>
+    <th class="<!--#echo var="y24q4"-->"><span>24Q4</span></th>
+    <th class="<!--#echo var="y25q1"-->"><span>25Q1</span></th>
+    <th class="<!--#echo var="y25q2"-->"><span>25Q2</span></th>
+    <th class="<!--#echo var="y25q3"-->"><span>25Q3</span></th>
+    <th class="<!--#echo var="y25q4"-->"><span>25Q4</span></th>
   </tr>
-  <tr>
-    <td class="gray">22.x</td>
-    <td class="gray">3.22.x</td>
-    <td title=23Q1 class="blue">IR</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="maintenance">
+    <th>3.x</th>
+    <td>22.x-25.x</td>
+    <td class="<!--#echo var="y23q1"--> active">3.22</td>
+    <td class="<!--#echo var="y23q2"--> active">3.23</td>
+    <td class="<!--#echo var="y23q3"--> active">3.24</td>
+    <td class="<!--#echo var="y23q4"--> active">3.25</td>
+    <td class="<!--#echo var="y24q1"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q2"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q3"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q4"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q2"-->"></td>
+    <td class="<!--#echo var="y25q3"-->"></td>
+    <td class="<!--#echo var="y25q4"-->"></td>
   </tr>
-  <tr>
-    <td class="gray">23.x</td>
-    <td class="gray">3.23.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2 class="blue">IR</td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">24.x</td>
-    <td class="gray">3.24.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">25.x</td>
-    <td class="gray">3.25.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1 class="green">PS</td>
-    <td title=24Q2 class="green">PS</td>
-    <td title=24Q3 class="green">PS</td>
-    <td title=24Q4 class="green">PS</td>
-    <td title=25Q1 class="red">SE</td>
-  </tr>
-  <tr>
-    <td class="gray">26.x</td>
-    <td class="gray">4.26.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1 class="blue">IR</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">27.x</td>
-    <td class="gray">4.27.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2 class="blue">IR</td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">28.x</td>
-    <td class="gray">4.28.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3 class="blue">IR</td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  <tr>
-    <td colspan="12">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
-  </tr>
-  </tr>
-  <tr>
-    <td class="gray">29.x</td>
-    <td class="gray"></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4 class="blue">IR</td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">30.x</td>
-    <td class="gray"></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1 class="blue">IR</td>
+  <tr class="active">
+    <th>4.x</th>
+    <td>26.x+</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"--> active">4.26</td>
+    <td class="<!--#echo var="y24q2"--> active">4.27</td>
+    <td class="<!--#echo var="y24q3"--> active">4.28</td>
+    <td class="<!--#echo var="y24q4"--> active">4.29</td>
+    <td class="<!--#echo var="y25q1"--> active">4.30</td>
+    <td class="<!--#echo var="y25q2"--> active">4.31</td>
+    <td class="<!--#echo var="y25q3"--> active">4.32</td>
+    <td class="<!--#echo var="y25q4"--> active">4.33</td>
   </tr>
 </table>
 
-<table>
-  <tr>
-    <td class="gray">
-      <b>Legend</b>
-    </td>
+**Legend**
+
+<table class="legend">
+  <tr class="active">
+    <th>Active</th>
+    <td>Minor and patch releases with new features, compatible changes and bug fixes.</td>
   </tr>
-  <tr>
-    <td class="blue">
-      Initial release (IR)
-    </td>
+  <tr class="maintenance">
+    <th>Maintenance</th>
+    <td>Patch releases with critical bug fixes.</td>
   </tr>
-  <tr>
-    <td class="green">
-      Public support (PS)
-    </td>
+  <tr class="end-of-life">
+    <th>End of life</th>
+    <td>Release is unsupported. Users should upgrade to a supported release.</td>
   </tr>
-  <tr>
-    <td class="red">
-      Support ends (SE)
-    </td>
+  <tr class="future">
+    <th>Future</th>
+    <td>Projected release. Shown for planning purposes.</td>
   </tr>
 </table>
 
@@ -1227,213 +679,123 @@ For specific versions supported, see
 
 ## Python {#python}
 
-This table provides specific dates for support duration.
+The protoc version can be inferred from the Protobuf Python minor version
+number. Example: Protobuf Python version 4.25.x uses protoc version 25.x.
 
-<table>
+Future plans are shown in *italics* and are subject to change.
+
+**Release support dates**
+
+<table class="version-table">
   <tr>
-    <th>Branch</th>
-    <th>Initial Release</th>
-    <th>Public Support Until</th>
+    <th>Protobuf Python</th>
+    <th>Release date</th>
+    <th>End of support</th>
   </tr>
-  <tr>
-    <td class="gray">4.22.x</td>
-    <td class="gray">16 Feb 2023</td>
-    <td class="gray"><s>8 May 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.23.x</td>
-    <td class="gray">8 May 2023</td>
-    <td class="gray"><s>8 Aug 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.24.x</td>
-    <td class="gray">8 Aug 2023</td>
-    <td class="gray"><s>1 Nov 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.25.x</td>
-    <td>1 Nov 2023</td>
+  <tr class="maintenance">
+    <th>4.x</th>
+    <td>16 Feb 2023</td>
     <td>31 Mar 2025</td>
   </tr>
-  <tr>
-    <td class="gray">5.26.x</td>
-    <td class="gray">13 Mar 2024</td>
-    <td class="gray"><s>23 May 2024</s></td>
+  <tr class="active">
+    <th>5.x</th>
+    <td>13 Mar 2024</td>
+    <td>31 Mar 2026</td>
   </tr>
-  <tr>
-    <td class="gray">5.27.x</td>
-    <td class="gray">23 May 2024</td>
-    <td class="gray"><s>28 Aug 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">5.28.x</td>
-    <td>28 Aug 2024</td>
+  <tr class="future">
+    <th>6.x</th>
+    <td>Q1 2025</td>
     <td>TBD</td>
   </tr>
 </table>
 
-This table graphically shows support durations.
+**Release support chart**
 
-<table>
+<table class="version-chart">
   <tr>
+    <th>Protobuf Python</th>
     <th>protoc</th>
-    <th>Python</th>
-    <th>23Q1</th>
-    <th>23Q2</th>
-    <th>23Q3</th>
-    <th>23Q4</th>
-    <th>24Q1</th>
-    <th>24Q2</th>
-    <th>24Q3</th>
-    <th>24Q4</th>
-    <th>25Q1</th>
+    <th class="<!--#echo var="y23q1"-->"><span>23Q1</span></th>
+    <th class="<!--#echo var="y23q2"-->"><span>23Q2</span></th>
+    <th class="<!--#echo var="y23q3"-->"><span>23Q3</span></th>
+    <th class="<!--#echo var="y23q4"-->"><span>23Q4</span></th>
+    <th class="<!--#echo var="y24q1"-->"><span>24Q1</span></th>
+    <th class="<!--#echo var="y24q2"-->"><span>24Q2</span></th>
+    <th class="<!--#echo var="y24q3"-->"><span>24Q3</span></th>
+    <th class="<!--#echo var="y24q4"-->"><span>24Q4</span></th>
+    <th class="<!--#echo var="y25q1"-->"><span>25Q1</span></th>
+    <th class="<!--#echo var="y25q2"-->"><span>25Q2</span></th>
+    <th class="<!--#echo var="y25q3"-->"><span>25Q3</span></th>
+    <th class="<!--#echo var="y25q4"-->"><span>25Q4</span></th>
   </tr>
-  <tr>
-    <td class="gray">22.x</td>
-    <td class="gray">4.22.x</td>
-    <td title=23Q1 class="blue">IR</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="maintenance">
+    <th>4.x</th>
+    <td>22.x-25.x</td>
+    <td class="<!--#echo var="y23q1"--> active">4.22</td>
+    <td class="<!--#echo var="y23q2"--> active">4.23</td>
+    <td class="<!--#echo var="y23q3"--> active">4.24</td>
+    <td class="<!--#echo var="y23q4"--> active">4.25</td>
+    <td class="<!--#echo var="y24q1"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y24q2"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y24q3"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y24q4"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">4.25</td>
+    <td class="<!--#echo var="y25q2"-->"></td>
+    <td class="<!--#echo var="y25q3"-->"></td>
+    <td class="<!--#echo var="y25q4"-->"></td>
   </tr>
-  <tr>
-    <td class="gray">23.x</td>
-    <td class="gray">4.23.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2 class="blue">IR</td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="active">
+    <th>5.x</th>
+    <td>26.x-29.x</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"--> active">5.26</td>
+    <td class="<!--#echo var="y24q2"--> active">5.27</td>
+    <td class="<!--#echo var="y24q3"--> active">5.28</td>
+    <td class="<!--#echo var="y24q4"--> active">5.29</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">5.29</td>
+    <td class="<!--#echo var="y25q2"--> maintenance">5.29</td>
+    <td class="<!--#echo var="y25q3"--> maintenance">5.29</td>
+    <td class="<!--#echo var="y25q4"--> maintenance">5.29</td>
   </tr>
-  <tr>
-    <td class="gray">24.x</td>
-    <td class="gray">4.24.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">25.x</td>
-    <td class="gray">4.25.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1 class="green">PS</td>
-    <td title=24Q2 class="green">PS</td>
-    <td title=24Q3 class="green">PS</td>
-    <td title=24Q4 class="green">PS</td>
-    <td title=25Q1 class="red">SE</td>
-  </tr>
-  <tr>
-    <td class="gray">26.x</td>
-    <td class="gray">5.26.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1 class="blue">IR</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">27.x</td>
-    <td class="gray">5.27.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2 class="blue">IR</td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">28.x</td>
-    <td class="gray">5.28.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3 class="blue">IR</td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td colspan="11">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
-  </tr>
-  <tr>
-    <td class="gray">29.x</td>
-    <td class="gray">5.29.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4 class="blue">IR</td>
-    <td title=25Q1 class="green">PS</td>
-  </tr>
-  <tr>
-    <td class="gray">30.x</td>
-    <td class="gray">6.30.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1 class="blue">IR</td>
+  <tr class="future">
+    <th>6.x</th>
+    <td>30.x+</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"-->"></td>
+    <td class="<!--#echo var="y24q2"-->"></td>
+    <td class="<!--#echo var="y24q3"-->"></td>
+    <td class="<!--#echo var="y24q4"-->"></td>
+    <td class="<!--#echo var="y25q1"--> active">6.30</td>
+    <td class="<!--#echo var="y25q2"--> active">6.31</td>
+    <td class="<!--#echo var="y25q3"--> active">6.32</td>
+    <td class="<!--#echo var="y25q4"--> active">6.33</td>
   </tr>
 </table>
 
-<table>
-  <tr>
-    <td class="gray">
-      <b>Legend</b>
-    </td>
+**Legend**
+
+<table class="legend">
+  <tr class="active">
+    <th>Active</th>
+    <td>Minor and patch releases with new features, compatible changes and bug fixes.</td>
   </tr>
-  <tr>
-    <td class="blue">
-      Initial release (IR)
-    </td>
+  <tr class="maintenance">
+    <th>Maintenance</th>
+    <td>Patch releases with critical bug fixes.</td>
   </tr>
-  <tr>
-    <td class="green">
-      Public support (PS)
-    </td>
+  <tr class="end-of-life">
+    <th>End of life</th>
+    <td>Release is unsupported. Users should upgrade to a supported release.</td>
   </tr>
-  <tr>
-    <td class="red">
-      Support ends (SE)
-    </td>
+  <tr class="future">
+    <th>Future</th>
+    <td>Projected release. Shown for planning purposes.</td>
   </tr>
 </table>
 
@@ -1447,218 +809,102 @@ For specific versions supported, see
 
 ## Ruby {#ruby}
 
-This table provides specific dates for support duration.
+The protoc version can be inferred from the Protobuf Ruby minor version number.
+Example: Protobuf Ruby version 3.25.x uses protoc version 25.x.
 
-<table>
+Future plans are shown in *italics* and are subject to change.
+
+**Release support dates**
+
+<table class="version-table">
   <tr>
-    <th>Branch</th>
-    <th>Initial Release</th>
-    <th>Public Support Until</th>
+    <th>Protobuf Ruby</th>
+    <th>Release date</th>
+    <th>End of support</th>
   </tr>
-  <tr>
-    <td class="gray">3.21.x</td>
-    <td class="gray">25 May 2022</td>
-    <td class="gray"><s>16 Feb 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.22.x</td>
-    <td class="gray">16 Feb 2023</td>
-    <td class="gray"><s>8 May 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.23.x</td>
-    <td class="gray">8 May 2023</td>
-    <td class="gray"><s>8 Aug 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.24.x</td>
-    <td class="gray">8 Aug 2023</td>
-    <td class="gray"><s>1 Nov 2023</s></td>
-  </tr>
-  <tr>
-    <td class="gray">3.25.x</td>
-    <td>1 Nov 2023</td>
+  <tr class="maintenance">
+    <th>3.x</th>
+    <td>16 Feb 2023</td>
     <td>31 Mar 2025</td>
   </tr>
-  <tr>
-    <td class="gray">4.26.x</td>
-    <td class="gray">13 Mar 2024</td>
-    <td class="gray"><s>23 May 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.27.x</td>
-    <td class="gray">23 May 2024</td>
-    <td class="gray"><s>28 Aug 2024</s></td>
-  </tr>
-  <tr>
-    <td class="gray">4.28.x</td>
-    <td>28 Aug 2024</td>
+  <tr class="active">
+    <th>4.x</th>
+    <td>13 Mar 2024</td>
     <td>TBD</td>
   </tr>
 </table>
 
-This table graphically shows support durations.
+**Release support chart**
 
-<table>
+<table class="version-chart">
   <tr>
+    <th>Protobuf Ruby</th>
     <th>protoc</th>
-    <th>Ruby</th>
-    <th>23Q1</th>
-    <th>23Q2</th>
-    <th>23Q3</th>
-    <th>23Q4</th>
-    <th>24Q1</th>
-    <th>24Q2</th>
-    <th>24Q3</th>
-    <th>24Q4</th>
-    <th>25Q1</th>
+    <th class="<!--#echo var="y23q1"-->"><span>23Q1</span></th>
+    <th class="<!--#echo var="y23q2"-->"><span>23Q2</span></th>
+    <th class="<!--#echo var="y23q3"-->"><span>23Q3</span></th>
+    <th class="<!--#echo var="y23q4"-->"><span>23Q4</span></th>
+    <th class="<!--#echo var="y24q1"-->"><span>24Q1</span></th>
+    <th class="<!--#echo var="y24q2"-->"><span>24Q2</span></th>
+    <th class="<!--#echo var="y24q3"-->"><span>24Q3</span></th>
+    <th class="<!--#echo var="y24q4"-->"><span>24Q4</span></th>
+    <th class="<!--#echo var="y25q1"-->"><span>25Q1</span></th>
+    <th class="<!--#echo var="y25q2"-->"><span>25Q2</span></th>
+    <th class="<!--#echo var="y25q3"-->"><span>25Q3</span></th>
+    <th class="<!--#echo var="y25q4"-->"><span>25Q4</span></th>
   </tr>
-  <tr>
-    <td class="gray">22.x</td>
-    <td class="gray">3.22.x</td>
-    <td title=23Q1 class="blue">IR</td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
+  <tr class="maintenance">
+    <th>3.x</th>
+    <td>22.x-25.x</td>
+    <td class="<!--#echo var="y23q1"--> active">3.22</td>
+    <td class="<!--#echo var="y23q2"--> active">3.23</td>
+    <td class="<!--#echo var="y23q3"--> active">3.24</td>
+    <td class="<!--#echo var="y23q4"--> active">3.25</td>
+    <td class="<!--#echo var="y24q1"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q2"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q3"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y24q4"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q1"--> maintenance">3.25</td>
+    <td class="<!--#echo var="y25q2"-->"></td>
+    <td class="<!--#echo var="y25q3"-->"></td>
+    <td class="<!--#echo var="y25q4"-->"></td>
   </tr>
-  <tr>
-    <td class="gray">23.x</td>
-    <td class="gray">3.23.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2 class="blue">IR</td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">24.x</td>
-    <td class="gray">3.24.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3 class="blue">IR</td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">25.x</td>
-    <td class="gray">3.25.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4 class="blue">IR</td>
-    <td title=24Q1 class="green">PS</td>
-    <td title=24Q2 class="green">PS</td>
-    <td title=24Q3 class="green">PS</td>
-    <td title=24Q4 class="green">PS</td>
-    <td title=25Q1 class="red">SE</td>
-  </tr>
-  <tr>
-    <td class="gray">26.x</td>
-    <td class="gray">4.26.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1 class="blue">IR</td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">27.x</td>
-    <td class="gray">4.27.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2 class="blue">IR</td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">28.x</td>
-    <td class="gray">4.28.x</td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3 class="blue">IR</td>
-    <td title=24Q4></td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td colspan="11">
-      The cells below are projections of future releases, but are not guarantees
-      <br/>that those releases will happen, or that they will happen on that
-      schedule.
-    </td>
-  </tr>
-  <tr>
-    <td class="gray">29.x</td>
-    <td class="gray"></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4 class="blue">IR</td>
-    <td title=25Q1></td>
-  </tr>
-  <tr>
-    <td class="gray">30.x</td>
-    <td class="gray"></td>
-    <td title=23Q1></td>
-    <td title=23Q2></td>
-    <td title=23Q3></td>
-    <td title=23Q4></td>
-    <td title=24Q1></td>
-    <td title=24Q2></td>
-    <td title=24Q3></td>
-    <td title=24Q4></td>
-    <td title=25Q1 class="blue">IR</td>
+  <tr class="active">
+    <th>4.x</th>
+    <td>26.x+</td>
+    <td class="<!--#echo var="y23q1"-->"></td>
+    <td class="<!--#echo var="y23q2"-->"></td>
+    <td class="<!--#echo var="y23q3"-->"></td>
+    <td class="<!--#echo var="y23q4"-->"></td>
+    <td class="<!--#echo var="y24q1"--> active">4.26</td>
+    <td class="<!--#echo var="y24q2"--> active">4.27</td>
+    <td class="<!--#echo var="y24q3"--> active">4.28</td>
+    <td class="<!--#echo var="y24q4"--> active">4.29</td>
+    <td class="<!--#echo var="y25q1"--> active">4.30</td>
+    <td class="<!--#echo var="y25q2"--> active">4.31</td>
+    <td class="<!--#echo var="y25q3"--> active">4.32</td>
+    <td class="<!--#echo var="y25q4"--> active">4.33</td>
   </tr>
 </table>
 
-<table>
-  <tr>
-    <td class="gray">
-      <b>Legend</b>
-    </td>
+**Legend**
+
+<table class="legend">
+  <tr class="active">
+    <th>Active</th>
+    <td>Minor and patch releases with new features, compatible changes and bug fixes.</td>
   </tr>
-  <tr>
-    <td class="blue">
-      Initial release (IR)
-    </td>
+  <tr class="maintenance">
+    <th>Maintenance</th>
+    <td>Patch releases with critical bug fixes.</td>
   </tr>
-  <tr>
-    <td class="green">
-      Public support (PS)
-    </td>
+  <tr class="end-of-life">
+    <th>End of life</th>
+    <td>Release is unsupported. Users should upgrade to a supported release.</td>
   </tr>
-  <tr>
-    <td class="red">
-      Support ends (SE)
-    </td>
+  <tr class="future">
+    <th>Future</th>
+    <td>Projected release. Shown for planning purposes.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
This documentation changes includes the following:

- Updates the UI for the Version Support page to make it easier to read
- Adds a new News entry about upcoming changes in v30
- Updates the proto-limits.md file to remove some applies-only-internally content
- Updates the Edition 2023 spec to reflect that the edition entry in a schema file can use either single quotes or double quotes around the edition number.