### PR TITLE
Note that Map fields cannot be `optional`

### DIFF
--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -1193,7 +1193,7 @@ map<string, Project> projects = 3;
 
 ### Maps Features {#maps-features}
 
-*   Map fields cannot be `repeated`.
+*   Map fields cannot be `repeated` or `optional`.
 *   Wire format ordering and map iteration ordering of map values is undefined,
     so you cannot rely on your map items being in a particular order.
 *   When generating text format for a `.proto`, maps are sorted by key. Numeric


### PR DESCRIPTION
This tripped me up: the documentation explicitly says that Map fields cannot be `repeated`, but it doesn't mention `optional`.

When trying to compile protobufs with a `map<string, Foo`>`, I get the following error:

```
rpc.proto:121:19:syntax error: unexpected '<'
rpc.proto:121:48:syntax error: unexpected '>'
```

See also: https://github.com/protobufjs/protobuf.js/issues/429