### PR TITLE
Documentation change

### DIFF
--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -20,6 +20,8 @@ New news topics will also be published to the
 The following news topics provide information in the reverse order in which it
 was released.
 
+*   [December 13, 2024](/news/2024-12-13) - Removing
+    `MutableRepeatedFieldRef<T>::Reserve()` in v30
 *   [December 4, 2024](/news/2024-12-04) - `DebugString`
     replaced
 *   [November 7, 2024](/news/2024-11-07) - More breaking


### PR DESCRIPTION
This documentation change includes the following:

* Adds a link to the new News article

PiperOrigin-RevId: 705974026
Change-Id: I9ef8058cdc999b33571c5f7035d15a4c368eff95