### PR TITLE
Documentation change

### DIFF
--- a/content/best-practices/api.md
+++ b/content/best-practices/api.md
@@ -1,5 +1,3 @@
-<!-- go/markdown -->
-
 +++
 title = "API Best Practices"
 weight = 100

--- a/content/getting-started/kotlintutorial.md
+++ b/content/getting-started/kotlintutorial.md
@@ -37,7 +37,7 @@ ways to solve this problem:
 
 -   Use kotlinx.serialization. This does not work very well if you need to share
     data with applications written in C++ or Python. kotlinx.serialization has a
-    [protobuf mode](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/formats.md#protobuf-experimental),
+    [protobuf mode](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/formats#protobuf-experimental),
     but this does not offer the full features of protocol buffers.
 -   You can invent an ad-hoc way to encode the data items into a single
     string -- such as encoding 4 ints as "12:3:-23:67". This is a simple and

--- a/content/programming-guides/editions.md
+++ b/content/programming-guides/editions.md
@@ -329,12 +329,91 @@ A scalar message field can have one of the following types – the table shows t
 type specified in the `.proto` file, and the corresponding type in the
 automatically generated class:
 
-<div style="overflow:auto;width:100%;">
-  <table style="width: 110%;">
+<div>
+  <table>
     <tbody>
       <tr>
-        <th>.proto Type</th>
+        <th>Proto Type</th>
         <th>Notes</th>
+      </tr>
+      <tr>
+        <td>double</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>float</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>int32</td>
+        <td>Uses variable-length encoding. Inefficient for encoding negative
+        numbers – if your field is likely to have negative values, use sint32
+        instead.</td>
+      </tr>
+      <tr>
+        <td>int64</td>
+        <td>Uses variable-length encoding. Inefficient for encoding negative
+        numbers – if your field is likely to have negative values, use sint64
+        instead.</td>
+      </tr>
+      <tr>
+        <td>uint32</td>
+        <td>Uses variable-length encoding.</td>
+      </tr>
+      <tr>
+        <td>uint64</td>
+        <td>Uses variable-length encoding.</td>
+      </tr>
+      <tr>
+        <td>sint32</td>
+        <td>Uses variable-length encoding. Signed int value. These more
+        efficiently encode negative numbers than regular int32s.</td>
+      </tr>
+      <tr>
+        <td>sint64</td>
+        <td>Uses variable-length encoding. Signed int value. These more
+        efficiently encode negative numbers than regular int64s.</td>
+      </tr>
+      <tr>
+        <td>fixed32</td>
+        <td>Always four bytes. More efficient than uint32 if values are often
+        greater than 2<sup>28</sup>.</td>
+      </tr>
+      <tr>
+        <td>fixed64</td>
+        <td>Always eight bytes. More efficient than uint64 if values are often
+        greater than 2<sup>56</sup>.</td>
+      </tr>
+      <tr>
+        <td>sfixed32</td>
+        <td>Always four bytes.</td>
+      </tr>
+      <tr>
+        <td>sfixed64</td>
+        <td>Always eight bytes.</td>
+      </tr>
+      <tr>
+        <td>bool</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>string</td>
+        <td>A string must always contain UTF-8 encoded or 7-bit ASCII text, and cannot
+        be longer than 2<sup>32</sup>.</td>
+      </tr>
+      <tr>
+        <td>bytes</td>
+        <td>May contain any arbitrary sequence of bytes no longer than 2<sup>32</sup>.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div>
+  <table style="width: 100%;overflow-x: scroll;">
+    <tbody>
+      <tr>
+        <th>Proto Type</th>
         <th>C++ Type</th>
         <th>Java/Kotlin Type<sup>[1]</sup></th>
         <th>Python Type<sup>[3]</sup></th>
@@ -347,7 +426,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>double</td>
-        <td></td>
         <td>double</td>
         <td>double</td>
         <td>float</td>
@@ -360,7 +438,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>float</td>
-        <td></td>
         <td>float</td>
         <td>float</td>
         <td>float</td>
@@ -373,9 +450,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>int32</td>
-        <td>Uses variable-length encoding. Inefficient for encoding negative
-        numbers – if your field is likely to have negative values, use sint32
-        instead.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -388,9 +462,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>int64</td>
-        <td>Uses variable-length encoding. Inefficient for encoding negative
-        numbers – if your field is likely to have negative values, use sint64
-        instead.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -403,7 +474,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>uint32</td>
-        <td>Uses variable-length encoding.</td>
         <td>uint32_t</td>
         <td>int<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -416,7 +486,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>uint64</td>
-        <td>Uses variable-length encoding.</td>
         <td>uint64_t</td>
         <td>long<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -429,8 +498,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sint32</td>
-        <td>Uses variable-length encoding. Signed int value. These more
-        efficiently encode negative numbers than regular int32s.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -443,8 +510,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sint64</td>
-        <td>Uses variable-length encoding. Signed int value. These more
-        efficiently encode negative numbers than regular int64s.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -457,8 +522,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>fixed32</td>
-        <td>Always four bytes. More efficient than uint32 if values are often
-        greater than 2<sup>28</sup>.</td>
         <td>uint32_t</td>
         <td>int<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -471,8 +534,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>fixed64</td>
-        <td>Always eight bytes. More efficient than uint64 if values are often
-        greater than 2<sup>56</sup>.</td>
         <td>uint64_t</td>
         <td>long<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -485,7 +546,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sfixed32</td>
-        <td>Always four bytes.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -498,7 +558,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sfixed64</td>
-        <td>Always eight bytes.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -511,7 +570,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>bool</td>
-        <td></td>
         <td>bool</td>
         <td>boolean</td>
         <td>bool</td>
@@ -524,8 +582,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>string</td>
-        <td>A string must always contain UTF-8 encoded or 7-bit ASCII text, and cannot
-        be longer than 2<sup>32</sup>.</td>
         <td>string</td>
         <td>String</td>
         <td>str/unicode<sup>[5]</sup></td>
@@ -538,10 +594,9 @@ automatically generated class:
       </tr>
       <tr>
         <td>bytes</td>
-        <td>May contain any arbitrary sequence of bytes no longer than 2<sup>32</sup>.</td>
         <td>string</td>
         <td>ByteString</td>
-        <td>str (Python 2)<br/>bytes (Python 3)</td>
+        <td>str (Python 2), bytes (Python 3)</td>
         <td>[]byte</td>
         <td>String (ASCII-8BIT)</td>
         <td>ByteString</td>
@@ -1440,7 +1495,17 @@ language in the relevant [API reference](/reference/).
     ```
 
 *   If the parser encounters multiple members of the same oneof on the wire,
-    only the last member seen is used in the parsed message.
+    only the last run of the last member seen is used in the parsed message.
+    When parsing data on the wire, starting at the beginning of the bytes,
+    evaluate the next value, and apply the following parsing rules:
+
+    *   First, check if a *different* field in the same oneof is currently set,
+        and if so clear it.
+
+    *   Then apply the contents as though the field was not in a oneof:
+
+        *   A primitive will overwrite any value already set
+        *   A message will merge into any value already set
 
 *   Extensions are not supported for oneof.
 

--- a/content/programming-guides/editions.md
+++ b/content/programming-guides/editions.md
@@ -1495,9 +1495,9 @@ language in the relevant [API reference](/reference/).
     ```
 
 *   If the parser encounters multiple members of the same oneof on the wire,
-    only the last run of the last member seen is used in the parsed message.
-    When parsing data on the wire, starting at the beginning of the bytes,
-    evaluate the next value, and apply the following parsing rules:
+    only the last member seen is used in the parsed message. When parsing data
+    on the wire, starting at the beginning of the bytes, evaluate the next
+    value, and apply the following parsing rules:
 
     *   First, check if a *different* field in the same oneof is currently set,
         and if so clear it.

--- a/content/programming-guides/field_presence.md
+++ b/content/programming-guides/field_presence.md
@@ -179,6 +179,12 @@ basic types (numeric, string, bytes, and enums), either. Oneof fields
 affirmatively expose presence, although the same set of hazzer methods may not
 generated as in proto2 APIs.
 
+This default behavior of not tracking presence without the `optional` label is
+different from the proto2 behavior. We reintroduced
+[explicit presence](/editions/features#field_presence) as
+the default in edition 2023. We recommend using the `optional` field with proto3
+unless you have a specific reason not to.
+
 Under the *implicit presence* discipline, the default value is synonymous with
 "not present" for purposes of serialization. To notionally "clear" a field (so
 it won't be serialized), an API user would set it to the default value.

--- a/content/programming-guides/proto-limits.md
+++ b/content/programming-guides/proto-limits.md
@@ -24,8 +24,7 @@ Empty message extended by singular fields (such as Boolean):
 
 *   ~4100 fields (proto2)
 
-Extensions are supported
-[only by proto2](/programming-guides/version-comparison#extensionsany).
+Extensions are not supported in proto3.
 
 To test this limitation, create a proto message with more than the upper bound
 number of fields and compile using a Java proto rule. The limit comes from JVM

--- a/content/programming-guides/proto2.md
+++ b/content/programming-guides/proto2.md
@@ -1570,9 +1570,9 @@ for your chosen language in the relevant
     ```
 
 *   If the parser encounters multiple members of the same oneof on the wire,
-    only the last run of the last member seen is used in the parsed message.
-    When parsing data on the wire, starting at the beginning of the bytes,
-    evaluate the next value, and apply the following parsing rules:
+    only the last member seen is used in the parsed message. When parsing data
+    on the wire, starting at the beginning of the bytes, evaluate the next
+    value, and apply the following parsing rules:
 
     *   First, check if a *different* field in the same oneof is currently set,
         and if so clear it.

--- a/content/programming-guides/proto2.md
+++ b/content/programming-guides/proto2.md
@@ -359,12 +359,91 @@ A scalar message field can have one of the following types – the table shows t
 type specified in the `.proto` file, and the corresponding type in the
 automatically generated class:
 
-<div style="overflow:auto;width:100%;">
-  <table style="width: 110%;">
+<div>
+  <table>
     <tbody>
       <tr>
-        <th>.proto Type</th>
+        <th>Proto Type</th>
         <th>Notes</th>
+      </tr>
+      <tr>
+        <td>double</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>float</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>int32</td>
+        <td>Uses variable-length encoding. Inefficient for encoding negative
+        numbers – if your field is likely to have negative values, use sint32
+        instead.</td>
+      </tr>
+      <tr>
+        <td>int64</td>
+        <td>Uses variable-length encoding. Inefficient for encoding negative
+        numbers – if your field is likely to have negative values, use sint64
+        instead.</td>
+      </tr>
+      <tr>
+        <td>uint32</td>
+        <td>Uses variable-length encoding.</td>
+      </tr>
+      <tr>
+        <td>uint64</td>
+        <td>Uses variable-length encoding.</td>
+      </tr>
+      <tr>
+        <td>sint32</td>
+        <td>Uses variable-length encoding. Signed int value. These more
+        efficiently encode negative numbers than regular int32s.</td>
+      </tr>
+      <tr>
+        <td>sint64</td>
+        <td>Uses variable-length encoding. Signed int value. These more
+        efficiently encode negative numbers than regular int64s.</td>
+      </tr>
+      <tr>
+        <td>fixed32</td>
+        <td>Always four bytes. More efficient than uint32 if values are often
+        greater than 2<sup>28</sup>.</td>
+      </tr>
+      <tr>
+        <td>fixed64</td>
+        <td>Always eight bytes. More efficient than uint64 if values are often
+        greater than 2<sup>56</sup>.</td>
+      </tr>
+      <tr>
+        <td>sfixed32</td>
+        <td>Always four bytes.</td>
+      </tr>
+      <tr>
+        <td>sfixed64</td>
+        <td>Always eight bytes.</td>
+      </tr>
+      <tr>
+        <td>bool</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>string</td>
+        <td>A string must always contain UTF-8 encoded or 7-bit ASCII text, and cannot
+        be longer than 2<sup>32</sup>.</td>
+      </tr>
+      <tr>
+        <td>bytes</td>
+        <td>May contain any arbitrary sequence of bytes no longer than 2<sup>32</sup>.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div>
+  <table style="width: 100%;overflow-x: scroll;">
+    <tbody>
+      <tr>
+        <th>Proto Type</th>
         <th>C++ Type</th>
         <th>Java/Kotlin Type<sup>[1]</sup></th>
         <th>Python Type<sup>[3]</sup></th>
@@ -377,7 +456,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>double</td>
-        <td></td>
         <td>double</td>
         <td>double</td>
         <td>float</td>
@@ -390,7 +468,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>float</td>
-        <td></td>
         <td>float</td>
         <td>float</td>
         <td>float</td>
@@ -403,9 +480,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>int32</td>
-        <td>Uses variable-length encoding. Inefficient for encoding negative
-        numbers – if your field is likely to have negative values, use sint32
-        instead.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -418,9 +492,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>int64</td>
-        <td>Uses variable-length encoding. Inefficient for encoding negative
-        numbers – if your field is likely to have negative values, use sint64
-        instead.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -433,7 +504,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>uint32</td>
-        <td>Uses variable-length encoding.</td>
         <td>uint32_t</td>
         <td>int<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -446,7 +516,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>uint64</td>
-        <td>Uses variable-length encoding.</td>
         <td>uint64_t</td>
         <td>long<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -459,8 +528,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sint32</td>
-        <td>Uses variable-length encoding. Signed int value. These more
-        efficiently encode negative numbers than regular int32s.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -473,8 +540,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sint64</td>
-        <td>Uses variable-length encoding. Signed int value. These more
-        efficiently encode negative numbers than regular int64s.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -487,8 +552,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>fixed32</td>
-        <td>Always four bytes. More efficient than uint32 if values are often
-        greater than 2<sup>28</sup>.</td>
         <td>uint32_t</td>
         <td>int<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -501,8 +564,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>fixed64</td>
-        <td>Always eight bytes. More efficient than uint64 if values are often
-        greater than 2<sup>56</sup>.</td>
         <td>uint64_t</td>
         <td>long<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -515,7 +576,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sfixed32</td>
-        <td>Always four bytes.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -528,7 +588,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sfixed64</td>
-        <td>Always eight bytes.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -541,7 +600,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>bool</td>
-        <td></td>
         <td>bool</td>
         <td>boolean</td>
         <td>bool</td>
@@ -554,11 +612,9 @@ automatically generated class:
       </tr>
       <tr>
         <td>string</td>
-        <td>A string must always contain UTF-8 encoded or 7-bit ASCII text, and cannot
-        be longer than 2<sup>32</sup>.</td>
         <td>string</td>
         <td>String</td>
-        <td>unicode (Python 2) or str (Python 3)</td>
+        <td>unicode (Python 2), str (Python 3)</td>
         <td>*string</td>
         <td>String (UTF-8)</td>
         <td>string</td>
@@ -568,7 +624,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>bytes</td>
-        <td>May contain any arbitrary sequence of bytes no longer than 2<sup>32</sup>.</td>
         <td>string</td>
         <td>ByteString</td>
         <td>bytes</td>
@@ -1515,7 +1570,17 @@ for your chosen language in the relevant
     ```
 
 *   If the parser encounters multiple members of the same oneof on the wire,
-    only the last member seen is used in the parsed message.
+    only the last run of the last member seen is used in the parsed message.
+    When parsing data on the wire, starting at the beginning of the bytes,
+    evaluate the next value, and apply the following parsing rules:
+
+    *   First, check if a *different* field in the same oneof is currently set,
+        and if so clear it.
+
+    *   Then apply the contents as though the field was not in a oneof:
+
+        *   A primitive will overwrite any value already set
+        *   A message will merge into any value already set
 
 *   Extensions are not supported for oneof.
 

--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -363,12 +363,91 @@ A scalar message field can have one of the following types – the table shows t
 type specified in the `.proto` file, and the corresponding type in the
 automatically generated class:
 
-<div style="overflow:auto;width:100%;">
-  <table style="width: 110%;">
+<div>
+  <table>
     <tbody>
       <tr>
-        <th>.proto Type</th>
+        <th>Proto Type</th>
         <th>Notes</th>
+      </tr>
+      <tr>
+        <td>double</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>float</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>int32</td>
+        <td>Uses variable-length encoding. Inefficient for encoding negative
+        numbers – if your field is likely to have negative values, use sint32
+        instead.</td>
+      </tr>
+      <tr>
+        <td>int64</td>
+        <td>Uses variable-length encoding. Inefficient for encoding negative
+        numbers – if your field is likely to have negative values, use sint64
+        instead.</td>
+      </tr>
+      <tr>
+        <td>uint32</td>
+        <td>Uses variable-length encoding.</td>
+      </tr>
+      <tr>
+        <td>uint64</td>
+        <td>Uses variable-length encoding.</td>
+      </tr>
+      <tr>
+        <td>sint32</td>
+        <td>Uses variable-length encoding. Signed int value. These more
+        efficiently encode negative numbers than regular int32s.</td>
+      </tr>
+      <tr>
+        <td>sint64</td>
+        <td>Uses variable-length encoding. Signed int value. These more
+        efficiently encode negative numbers than regular int64s.</td>
+      </tr>
+      <tr>
+        <td>fixed32</td>
+        <td>Always four bytes. More efficient than uint32 if values are often
+        greater than 2<sup>28</sup>.</td>
+      </tr>
+      <tr>
+        <td>fixed64</td>
+        <td>Always eight bytes. More efficient than uint64 if values are often
+        greater than 2<sup>56</sup>.</td>
+      </tr>
+      <tr>
+        <td>sfixed32</td>
+        <td>Always four bytes.</td>
+      </tr>
+      <tr>
+        <td>sfixed64</td>
+        <td>Always eight bytes.</td>
+      </tr>
+      <tr>
+        <td>bool</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>string</td>
+        <td>A string must always contain UTF-8 encoded or 7-bit ASCII text, and cannot
+        be longer than 2<sup>32</sup>.</td>
+      </tr>
+      <tr>
+        <td>bytes</td>
+        <td>May contain any arbitrary sequence of bytes no longer than 2<sup>32</sup>.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div>
+  <table style="width: 100%;overflow-x: scroll;">
+    <tbody>
+      <tr>
+        <th>Proto Type</th>
         <th>C++ Type</th>
         <th>Java/Kotlin Type<sup>[1]</sup></th>
         <th>Python Type<sup>[3]</sup></th>
@@ -381,7 +460,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>double</td>
-        <td></td>
         <td>double</td>
         <td>double</td>
         <td>float</td>
@@ -394,7 +472,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>float</td>
-        <td></td>
         <td>float</td>
         <td>float</td>
         <td>float</td>
@@ -407,9 +484,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>int32</td>
-        <td>Uses variable-length encoding. Inefficient for encoding negative
-        numbers – if your field is likely to have negative values, use sint32
-        instead.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -422,9 +496,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>int64</td>
-        <td>Uses variable-length encoding. Inefficient for encoding negative
-        numbers – if your field is likely to have negative values, use sint64
-        instead.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -437,7 +508,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>uint32</td>
-        <td>Uses variable-length encoding.</td>
         <td>uint32_t</td>
         <td>int<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -450,7 +520,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>uint64</td>
-        <td>Uses variable-length encoding.</td>
         <td>uint64_t</td>
         <td>long<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -463,9 +532,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sint32</td>
-        <td>Uses variable-length encoding. Signed int value. These more
-        efficiently encode negative numbers than regular int32s.</td>
-        <td>int32_t</td>
         <td>int</td>
         <td>int</td>
         <td>int32</td>
@@ -477,9 +543,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sint64</td>
-        <td>Uses variable-length encoding. Signed int value. These more
-        efficiently encode negative numbers than regular int64s.</td>
-        <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
         <td>int64</td>
@@ -491,8 +554,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>fixed32</td>
-        <td>Always four bytes. More efficient than uint32 if values are often
-        greater than 2<sup>28</sup>.</td>
         <td>uint32_t</td>
         <td>int<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -505,8 +566,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>fixed64</td>
-        <td>Always eight bytes. More efficient than uint64 if values are often
-        greater than 2<sup>56</sup>.</td>
         <td>uint64_t</td>
         <td>long<sup>[2]</sup></td>
         <td>int/long<sup>[4]</sup></td>
@@ -519,7 +578,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sfixed32</td>
-        <td>Always four bytes.</td>
         <td>int32_t</td>
         <td>int</td>
         <td>int</td>
@@ -532,7 +590,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>sfixed64</td>
-        <td>Always eight bytes.</td>
         <td>int64_t</td>
         <td>long</td>
         <td>int/long<sup>[4]</sup></td>
@@ -545,7 +602,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>bool</td>
-        <td></td>
         <td>bool</td>
         <td>boolean</td>
         <td>bool</td>
@@ -558,8 +614,6 @@ automatically generated class:
       </tr>
       <tr>
         <td>string</td>
-        <td>A string must always contain UTF-8 encoded or 7-bit ASCII text, and cannot
-        be longer than 2<sup>32</sup>.</td>
         <td>string</td>
         <td>String</td>
         <td>str/unicode<sup>[5]</sup></td>
@@ -572,10 +626,9 @@ automatically generated class:
       </tr>
       <tr>
         <td>bytes</td>
-        <td>May contain any arbitrary sequence of bytes no longer than 2<sup>32</sup>.</td>
         <td>string</td>
         <td>ByteString</td>
-        <td>str (Python 2)<br/>bytes (Python 3)</td>
+        <td>str (Python 2), bytes (Python 3)</td>
         <td>[]byte</td>
         <td>String (ASCII-8BIT)</td>
         <td>ByteString</td>
@@ -1116,7 +1169,17 @@ language in the relevant [API reference](/reference/).
     ```
 
 *   If the parser encounters multiple members of the same oneof on the wire,
-    only the last member seen is used in the parsed message.
+    only the last run of the last member seen is used in the parsed message.
+    When parsing data on the wire, starting at the beginning of the bytes,
+    evaluate the next value, and apply the following parsing rules:
+
+    *   First, check if a *different* field in the same oneof is currently set,
+        and if so clear it.
+
+    *   Then apply the contents as though the field was not in a oneof:
+
+        *   A primitive will overwrite any value already set
+        *   A message will merge into any value already set
 
 *   A oneof cannot be `repeated`.
 

--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -1169,9 +1169,9 @@ language in the relevant [API reference](/reference/).
     ```
 
 *   If the parser encounters multiple members of the same oneof on the wire,
-    only the last run of the last member seen is used in the parsed message.
-    When parsing data on the wire, starting at the beginning of the bytes,
-    evaluate the next value, and apply the following parsing rules:
+    only the last member seen is used in the parsed message. When parsing data
+    on the wire, starting at the beginning of the bytes, evaluate the next
+    value, and apply the following parsing rules:
 
     *   First, check if a *different* field in the same oneof is currently set,
         and if so clear it.

--- a/content/programming-guides/style.md
+++ b/content/programming-guides/style.md
@@ -135,7 +135,7 @@ For more service-related guidance, see
 and
 [Don't Include Primitive Types in a Top-level Request or Response Proto](/programming-guides/api#dont-include-primitive-types)
 in the API Best Practices topic, and
-[Define Messages in Separate Files](/best-practices/dos-donts.md#separate-files)
+[Define Messages in Separate Files](/best-practices/dos-donts#separate-files)
 in Proto Best Practices.
 
 ## Things to Avoid {#avoid}

--- a/content/reference/go/go-generated-opaque.md
+++ b/content/reference/go/go-generated-opaque.md
@@ -175,7 +175,7 @@ protoc […] --go_opt=default_api_level=API_HYBRID
 
 To override the default API level for a specific file (instead of all files),
 use the `apilevelM` mapping flag (similar to [the `M` flag for import
-paths](/reference/go/go-generated/#package)):
+paths](#package)):
 
 ```
 protoc […] --go_opt=apilevelMhello.proto=API_HYBRID

--- a/content/support/migration.md
+++ b/content/support/migration.md
@@ -41,7 +41,7 @@ In v22.0, we removed all Autotools support from the protobuf compiler and the
 C++ runtime. If you're using Autotools to build either of these, you must
 migrate to [CMake](http://cmake.org) or
 [Bazel](http://bazel.build). We have some
-[dedicated instructions](https://github.com/protocolbuffers/protobuf/blob/main/cmake/README.md)
+[dedicated instructions](https://github.com/protocolbuffers/protobuf/blob/main/cmake/README)
 for setting up protobuf with CMake.
 
 ### Abseil Dependency {#abseil}
@@ -94,7 +94,7 @@ notable changes include:
 
     *   For CMake builds, we will first look for an existing Abseil installation
         pulled in by the top-level CMake configuration (see
-        [instructions](https://github.com/abseil/abseil-cpp/blob/master/CMake/README.md#traditional-cmake-set-up)).
+        [instructions](https://github.com/abseil/abseil-cpp/blob/master/CMake/README#traditional-cmake-set-up)).
         Otherwise, if `protobuf_ABSL_PROVIDER` is set to `module` (its default)
         we will attempt to build and link Abseil from our git
         [submodule](https://github.com/protocolbuffers/protobuf/tree/main/third_party).
@@ -109,7 +109,7 @@ Prior to v22.x, Protobuf incorrectly removed the macro definition for
 including `<protobuf/util/time_util.h>`. Starting with v22.x, Protobuf preserves
 the macro definition. This may break customer code relying on the previous
 behavior, such as if they use the expression
-[`google::protobuf::util::TimeUtil::GetCurrentTime()`](/reference/cpp/api-docs/google.protobuf.util.time_util.md#TimeUtil).
+[`google::protobuf::util::TimeUtil::GetCurrentTime()`](/reference/cpp/api-docs/google.protobuf.util.time_util#TimeUtil).
 
 To migrate your app to the new behavior, change your code to do one of the
 following:

--- a/content/support/version-support.md
+++ b/content/support/version-support.md
@@ -468,7 +468,7 @@ For specific versions supported, see
 On Android, Protobuf supports the minimum SDK version that is supported by
 [Google Play services](https://developers.google.com/android/guides/setup) and
 is the default in
-[Jetpack](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/docs/api_guidelines/modules.md#module-minsdkversion).
+[Jetpack](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/docs/api_guidelines/modules#module-minsdkversion).
 If both versions differ, the lower version is supported.
 
 ## Objective-C {#objc}


### PR DESCRIPTION
This documentation changes includes the following:

- Removes from `api.md` a tag used internally that prevents rendering
- Removes `.md` from all links to fix those links that it breaks
- Splits the scalar values tables into two to make them easier to read (proto2, proto3, editions topics)
- Clarifies that Editions are supported in proto2 and editions, but not proto3
- Updates language in `/programming-guides/editions.md`
- Fixes a link in `/reference/go/go-generated-opaque.md`
- Adds an explanation of default behavior for presence to the `/programming-guides/field_presence.md` topic.
- Updates wording in the Oneof sections of the proto2, proto3, and editions topics