### PR TITLE
Explicitly name std::string for c++ string type

### DIFF
--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -614,7 +614,7 @@ automatically generated class:
       </tr>
       <tr>
         <td>string</td>
-        <td>string</td>
+        <td>std::string</td>
         <td>String</td>
         <td>str/unicode<sup>[5]</sup></td>
         <td>string</td>
@@ -626,7 +626,7 @@ automatically generated class:
       </tr>
       <tr>
         <td>bytes</td>
-        <td>string</td>
+        <td>std::string</td>
         <td>ByteString</td>
         <td>str (Python 2), bytes (Python 3)</td>
         <td>[]byte</td>


### PR DESCRIPTION
Naming std::string explicitly helps understand protocolbuffers string allocation strategy.