### PR TITLE
Documentation change

### DIFF
--- a/content/best-practices/api.md
+++ b/content/best-practices/api.md
@@ -124,7 +124,7 @@ The following are exceptions to the rule:
     opaquely as possible so that you don't create a dependency nexus. Consider
     using extensions or [Encode Opaque Data in Strings by Web-safe Encoding
     Binary Proto
-    Serialization](/programming-guides/api#encode-opaque-data-in-strings).
+    Serialization](/best-practices/api#encode-opaque-data-in-strings).
 
 ## For Mutations, Support Partial Updates or Append-Only Updates, Not Full Replaces {#support-partial-updates}
 

--- a/content/editions/overview.md
+++ b/content/editions/overview.md
@@ -237,7 +237,7 @@ features not explicitly set conform to the behavior defined in the edition
 version used for the .proto file.
 
 The following code sample shows some features being set at the file, field, and
-enum level. The settings are in the highlighted lines:
+enum level.
 
 ```proto {highlight="lines:3,7,16"}
 edition = "2023";
@@ -333,6 +333,5 @@ special wire-format that groups used is still available by using `DELIMITED`
 message encoding.
 
 **Required label.** The `required` label, available only in proto2, is
-unavailable in editions. The underlying functionality is still available (but
-[discouraged](/programming-guides/required-considered-harmful))
+unavailable in editions. The underlying functionality is still available
 by using `features.field_presence=LEGACY_REQUIRED`.

--- a/content/programming-guides/deserialize-debug.md
+++ b/content/programming-guides/deserialize-debug.md
@@ -24,7 +24,7 @@ and a randomized-length whitespace sequence. The new debugging format looks as
 follows:
 
 ```none
-goo.gle/nodeserialize
+goo.gle/debugstr
 spii_field: [REDACTED]
 normal_field: "value"
 ```

--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -616,7 +616,7 @@ automatically generated class:
       </tr>
       <tr>
         <td>string</td>
-        <td>string</td>
+        <td>std::string</td>
         <td>String</td>
         <td>str/unicode<sup>[5]</sup></td>
         <td>string</td>
@@ -628,7 +628,7 @@ automatically generated class:
       </tr>
       <tr>
         <td>bytes</td>
-        <td>string</td>
+        <td>std::string</td>
         <td>ByteString</td>
         <td>str (Python 2), bytes (Python 3)</td>
         <td>[]byte</td>

--- a/content/reference/go/go-generated-opaque.md
+++ b/content/reference/go/go-generated-opaque.md
@@ -210,6 +210,21 @@ which provides a reflection-based view of the message.
 
 The `optimize_for` option does not affect the output of the Go code generator.
 
+When multiple goroutines concurrently access the same message, the following
+rules apply:
+
+*   Accessing (reading) fields concurrently is safe, with one exception:
+    *   Accessing a [lazy field](https://github.com/protocolbuffers/protobuf/blob/cacb096002994000f8ccc6d9b8e1b5b0783ee561/src/google/protobuf/descriptor.proto#L609)
+        for the first time is a modification.
+*   Modifying different fields in the same message is safe.
+*   Modifying a field concurrently is not safe.
+*   Modifying a message in any way concurrently with functions of the
+    [`proto` package](https://pkg.go.dev/google.golang.org/protobuf/proto?tab=doc),
+    such as
+    [`proto.Marshal`](https://pkg.go.dev/google.golang.org/protobuf/proto#Marshal)
+    or [`proto.Size`](https://pkg.go.dev/google.golang.org/protobuf/proto#Size)
+    is not safe.
+
 ### Nested Types
 
 A message can be declared inside another message. For example:

--- a/content/reference/go/go-generated.md
+++ b/content/reference/go/go-generated.md
@@ -209,6 +209,21 @@ which provides a reflection-based view of the message.
 
 The `optimize_for` option does not affect the output of the Go code generator.
 
+When multiple goroutines concurrently access the same message, the following
+rules apply:
+
+*   Accessing (reading) fields concurrently is safe, with one exception:
+    *   Accessing a [lazy field](https://github.com/protocolbuffers/protobuf/blob/cacb096002994000f8ccc6d9b8e1b5b0783ee561/src/google/protobuf/descriptor.proto#L609)
+        for the first time is a modification.
+*   Modifying different fields in the same message is safe.
+*   Modifying a field concurrently is not safe.
+*   Modifying a message in any way concurrently with functions of the
+    [`proto` package](https://pkg.go.dev/google.golang.org/protobuf/proto?tab=doc),
+    such as
+    [`proto.Marshal`](https://pkg.go.dev/google.golang.org/protobuf/proto#Marshal)
+    or [`proto.Size`](https://pkg.go.dev/google.golang.org/protobuf/proto#Size)
+    is not safe.
+
 ### Nested Types
 
 A message can be declared inside another message. For example:


### PR DESCRIPTION
This documentation change includes the following:

* Fixes links to remove redirects
* Removes some content that applies only internally at Google
* Updates the code samples for the Deserializing Debug Proto Representations topic
* Corrects C++ data types in the Scalar Value Types table
* Adds information about what happens when multiple goroutines concurrently access the same message

PiperOrigin-RevId: 730923238
Change-Id: I9555d3c880fed96dadb280cbe613f2f9cba4d298