### PR TITLE
Remove outdated information from csharp generated code guide

### DIFF
--- a/content/reference/csharp/csharp-generated.md
+++ b/content/reference/csharp/csharp-generated.md
@@ -18,7 +18,12 @@ syntax starting from release 3.10. Refer to the
 details of the semantics of `proto2` definitions, and see
 `docs/csharp/proto2.md`
 ([view on GitHub](https://github.com/protocolbuffers/protobuf/blob/master/docs/csharp/proto2.md))
-for details on the generated C\# code for proto2.
+for details on the generated C\# code for proto2.  
+
+Starting from release 3.27, the protobuf compiler can generate C\# interfaces
+for definitions using `editions`. Refer to the
+[editions language guide](/programming-guides/editions) for
+details of the semantics of `editions` definitions.
 {{% /alert %}}
 
 ## Compiler Invocation {#invocation}

--- a/content/reference/csharp/csharp-generated.md
+++ b/content/reference/csharp/csharp-generated.md
@@ -31,13 +31,6 @@ subdirectories of the specified directory. The compiler creates a single source
 file for each `.proto` file input, defaulting to an extension of `.cs` but
 configurable via compiler options.
 
-Only `proto3` messages are supported by the C\# code generator. Ensure that each
-`.proto` file begins with a declaration of:
-
-```proto
-syntax = "proto3";
-```
-
 ### C\#-specific Options {#compiler_options}
 
 You can provide further C\# options to the protocol buffer compiler using the


### PR DESCRIPTION
This documentation change includes the following:
- Removed a line in the [C# Generated Code Guide](https://protobuf.dev/reference/csharp/csharp-generated/) that claims the C# code generator only supports `proto3`.
- Added `editions` support details to the note at the top of the page. 

Closes #234