### PR TITLE
Fix outdated note on return type of SerializeToString

### DIFF
--- a/content/getting-started/pythontutorial.md
+++ b/content/getting-started/pythontutorial.md
@@ -314,8 +314,7 @@ of your chosen type using the protocol buffer
 include:
 
 -   `SerializeToString()`: serializes the message and returns it as a string.
-    Note that the bytes are binary, not text; we only use the `str` type as a
-    convenient container.
+    Note that the return value is `bytes` (binary), not `str` (text).
 -   `ParseFromString(data)`: parses a message from the given string.
 
 These are just a couple of the options provided for parsing and serialization.


### PR DESCRIPTION
The correct return type of this functions is not `str` at all;¹ it appears that this documentation was not updated when the implementation moved from Python 2 to 3.

¹ https://github.com/python/typeshed/blob/1a9eef437a11c77817266961869ca66c49a14ac2/stubs/protobuf/google/protobuf/message.pyi#L26