### PR TITLE
Fix field number in expanded repeated field example

### DIFF
--- a/content/programming-guides/encoding.md
+++ b/content/programming-guides/encoding.md
@@ -340,10 +340,10 @@ records for the same field with respect to each other is preserved. Thus, this
 could look like the following:
 
 ```proto
-5: 1
-5: 2
+6: 1
+6: 2
 4: {"hello"}
-5: 3
+6: 3
 ```
 
 Only repeated fields of primitive numeric types can be declared "packed". These


### PR DESCRIPTION
> ```
> message Test4 {
>   string d = 4;
>   repeated int32 e = 6;
> }
> ```
> and we construct a Test4 message with d set to "hello", and e set to 1, 2, and 3

So field number for 1, 2, and 3 should be 6 not 5?