### PR TITLE
Add installation of goimports to go opaque migration guide

### DIFF
--- a/content/reference/go/opaque-migration.md
+++ b/content/reference/go/opaque-migration.md
@@ -66,6 +66,7 @@ To install the migration tool, use:
 
 ```
 go install google.golang.org/open2opaque@latest
+go install golang.org/x/tools/cmd/goimports@latest
 ```
 
 {{% alert title="Note" color="info" %}}If


### PR DESCRIPTION
The [`open2opaque` tool uses the `goimports` tool to fix build after the auto migration](https://github.com/golang/open2opaque/blob/87af3f7ec9fb143e52a35fdef6c7f185d7d68c7c/internal/o2o/rewrite/rewrite.go#L576), but the `goimports` is not installed by default. This change ensures the `goimports` tool properly installed before migration.