### PR TITLE
Update example to match best practices

### DIFF
--- a/content/programming-guides/proto3.md
+++ b/content/programming-guides/proto3.md
@@ -1487,7 +1487,7 @@ Here are a few of the most commonly used options:
     classes/enums/etc. If not generating Java code, this option has no effect.
 
     ```proto
-    option java_outer_classname = "Ponycopter";
+    option java_outer_classname = "PonycopterProto";
     ```
 
 *   `java_multiple_files` (file option): If false, only a single `.java` file


### PR DESCRIPTION
Outer classname should be usually suffixed with Proto: https://protobuf.dev/best-practices/dos-donts/#java-outer-classname