### PR TITLE
Update encoding.md with clarified Test4 message examples

### DIFF
--- a/content/programming-guides/encoding.md
+++ b/content/programming-guides/encoding.md
@@ -323,7 +323,8 @@ message Test4 {
 ```
 
 and we construct a `Test4` message with `d` set to `"hello"`, and `e` set to
-`1`, `2`, and `3`, this *could* be encoded as `` `3206038e029ea705` ``, or
+`3`, `270`, and `86942` (varints of byte length `1`, `2`, and `3`, respectively)
+this *could* be encoded as `` `220568656c6c6f3206038e029ea705` ``, or
 written out as Protoscope,
 
 ```proto


### PR DESCRIPTION
Clarified encoding examples for Test4 message in documentation.

This resolves issue https://github.com/protocolbuffers/protocolbuffers.github.io/issues/293.