### PR TITLE
Fix edition 2024 example groupmessage field number

### DIFF
--- a/content/reference/protobuf/edition-2024-spec.md
+++ b/content/reference/protobuf/edition-2024-spec.md
@@ -429,6 +429,6 @@ message Foo {
   message GroupMessage {
     bool a = 1;
   }
-  GroupMessage groupmessage = [features.message_encoding = DELIMITED];
+  GroupMessage groupmessage = 1 [features.message_encoding = DELIMITED];
 }
 ```


### PR DESCRIPTION
This adds a missing `fieldNumber` int to the example for edition 2024 proto file.