### PR TITLE
doc: update API documentation for protoc plugins

### DIFF
--- a/content/reference/cpp/api-docs/google.protobuf.compiler.plugin.pb.md
+++ b/content/reference/cpp/api-docs/google.protobuf.compiler.plugin.pb.md
@@ -10,38 +10,12 @@ type = "docs"
 
 <pre>// Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
-// https://developers.google.com/protocol-buffers/
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-//
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
 
 // Author: kenton@google.com (Kenton Varda)
-//
-// WARNING:  The plugin interface is currently EXPERIMENTAL and is subject to
-//   change.
 //
 // protoc (aka the Protocol Compiler) can be extended via plugins.  A plugin is
 // just a program that reads a CodeGeneratorRequest from stdin and writes a
@@ -60,9 +34,10 @@ package google.protobuf.compiler;
 option java_package = "com.google.protobuf.compiler";
 option java_outer_classname = "PluginProtos";
 
-option go_package = "google.golang.org/protobuf/types/pluginpb";
-
 import "google/protobuf/descriptor.proto";
+
+option csharp_namespace = "Google.Protobuf.Compiler";
+option go_package = "google.golang.org/protobuf/types/pluginpb";
 
 // The version number of protocol compiler.
 message Version {
@@ -88,6 +63,11 @@ message CodeGeneratorRequest {
   // they import.  The files will appear in topological order, so each file
   // appears before any file that imports it.
   //
+  // Note: the files listed in files_to_generate will include runtime-retention
+  // options only, but all other files will include source-retention options.
+  // The source_file_descriptors field below is available in case you need
+  // source-retention options for files_to_generate.
+  //
   // protoc guarantees that all proto_files will be written after
   // the fields above, even though this is not technically guaranteed by the
   // protobuf wire format.  This theoretically could allow a plugin to stream
@@ -100,9 +80,13 @@ message CodeGeneratorRequest {
   // fully qualified.
   repeated FileDescriptorProto proto_file = 15;
 
+  // File descriptors with all options, including source-retention options.
+  // These descriptors are only provided for the files listed in
+  // files_to_generate.
+  repeated FileDescriptorProto source_file_descriptors = 17;
+
   // The version number of protocol compiler.
   optional Version compiler_version = 3;
-
 }
 
 // The plugin writes an encoded CodeGeneratorResponse to stdout.
@@ -125,7 +109,20 @@ message CodeGeneratorResponse {
   enum Feature {
     FEATURE_NONE = 0;
     FEATURE_PROTO3_OPTIONAL = 1;
+    FEATURE_SUPPORTS_EDITIONS = 2;
   }
+
+  // The minimum edition this plugin supports.  This will be treated as an
+  // Edition enum, but we want to allow unknown values.  It should be specified
+  // according the edition enum value, *not* the edition number.  Only takes
+  // effect for plugins that have FEATURE_SUPPORTS_EDITIONS set.
+  optional int32 minimum_edition = 3;
+
+  // The maximum edition this plugin supports.  This will be treated as an
+  // Edition enum, but we want to allow unknown values.  It should be specified
+  // according the edition enum value, *not* the edition number.  Only takes
+  // effect for plugins that have FEATURE_SUPPORTS_EDITIONS set.
+  optional int32 maximum_edition = 4;
 
   // Represents a single generated file.
   message File {
@@ -142,53 +139,52 @@ message CodeGeneratorResponse {
     // CodeGeneratorResponse before writing files to disk.
     optional string name = 1;
 
-// If non-empty, indicates that the named file should already exist, and the
-// content here is to be inserted into that file at a defined insertion
-// point.  This feature allows a code generator to extend the output
-// produced by another code generator.  The original generator may provide
-// insertion points by placing special annotations in the file that look
-// like:
-//   @@protoc_insertion_point(NAME)
-// The annotation can have arbitrary text before and after it on the line,
-// which allows it to be placed in a comment.  NAME should be replaced with
-// an identifier naming the point -- this is what other generators will use
-// as the insertion_point.  Code inserted at this point will be placed
-// immediately above the line containing the insertion point (thus multiple
-// insertions to the same point will come out in the order they were added).
-// The double-@ is intended to make it unlikely that the generated code
-// could contain things that look like insertion points by accident.
-//
-// For example, the C++ code generator places the following line in the
-// .pb.h files that it generates:
-//   // @@protoc_insertion_point(namespace_scope)
-// This line appears within the scope of the file's package namespace, but
-// outside of any particular class.  Another plugin can then specify the
-// insertion_point "namespace_scope" to generate additional classes or
-// other declarations that should be placed in this scope.
-//
-// Note that if the line containing the insertion point begins with
-// whitespace, the same whitespace will be added to every line of the
-// inserted text.  This is useful for languages like Python, where
-// indentation matters.  In these languages, the insertion point comment
-// should be indented the same amount as any inserted code will need to be
-// in order to work correctly in that context.
-//
-// The code generator that generates the initial file and the one which
-// inserts into it must both run as part of a single invocation of protoc.
-// Code generators are executed in the order in which they appear on the
-// command line.
-//
-// If |insertion_point| is present, |name| must also be present.
-optional string insertion_point = 2;
+    // If non-empty, indicates that the named file should already exist, and the
+    // content here is to be inserted into that file at a defined insertion
+    // point.  This feature allows a code generator to extend the output
+    // produced by another code generator.  The original generator may provide
+    // insertion points by placing special annotations in the file that look
+    // like:
+    //   @@protoc_insertion_point(NAME)
+    // The annotation can have arbitrary text before and after it on the line,
+    // which allows it to be placed in a comment.  NAME should be replaced with
+    // an identifier naming the point -- this is what other generators will use
+    // as the insertion_point.  Code inserted at this point will be placed
+    // immediately above the line containing the insertion point (thus multiple
+    // insertions to the same point will come out in the order they were added).
+    // The double-@ is intended to make it unlikely that the generated code
+    // could contain things that look like insertion points by accident.
+    //
+    // For example, the C++ code generator places the following line in the
+    // .pb.h files that it generates:
+    //   // @@protoc_insertion_point(namespace_scope)
+    // This line appears within the scope of the file's package namespace, but
+    // outside of any particular class.  Another plugin can then specify the
+    // insertion_point "namespace_scope" to generate additional classes or
+    // other declarations that should be placed in this scope.
+    //
+    // Note that if the line containing the insertion point begins with
+    // whitespace, the same whitespace will be added to every line of the
+    // inserted text.  This is useful for languages like Python, where
+    // indentation matters.  In these languages, the insertion point comment
+    // should be indented the same amount as any inserted code will need to be
+    // in order to work correctly in that context.
+    //
+    // The code generator that generates the initial file and the one which
+    // inserts into it must both run as part of a single invocation of protoc.
+    // Code generators are executed in the order in which they appear on the
+    // command line.
+    //
+    // If |insertion_point| is present, |name| must also be present.
+    optional string insertion_point = 2;
 
-// The file contents.
-optional string content = 15;
+    // The file contents.
+    optional string content = 15;
 
-// Information describing the file content being inserted. If an insertion
-// point is used, this information will be appropriately offset and inserted
-// into the code generation metadata for the generated files.
-optional GeneratedCodeInfo generated_code_info = 16;
-
+    // Information describing the file content being inserted. If an insertion
+    // point is used, this information will be appropriately offset and inserted
+    // into the code generation metadata for the generated files.
+    optional GeneratedCodeInfo generated_code_info = 16;
   }
   repeated File file = 15;
 }


### PR DESCRIPTION
Just copied the content from [current protobuf repo](https://github.com/protocolbuffers/protobuf/blob/c88ae99513a3f3e74e324a50e9da45476c4cb0a2/src/google/protobuf/compiler/plugin.proto)