### PR TITLE
Fix release_nested_message typo in C++ arenas guide

### DIFF
--- a/content/reference/cpp/arenas.md
+++ b/content/reference/cpp/arenas.md
@@ -474,7 +474,7 @@ The following code makes inefficient usage of the `release_...()` API:
 ```cpp
 arena_message_2->set_allocated_nested_message(arena_message_1->release_nested_message());
 
-arena_message_1->release_message(); // returns a copy of the underlying nested_message and deletes underlying pointer
+arena_message_1->release_nested_message(); // returns a copy of the underlying nested_message and deletes underlying pointer
 ```
 
 Using the "unsafe arena" version instead avoids the copy:


### PR DESCRIPTION
## Summary
In the inefficient arena `release_...()` example, the sample called `release_message()` even though the field used throughout the snippet is `nested_message`.

This updates that call to `release_nested_message()` so it matches `set_allocated_nested_message` and the unsafe arena APIs in the same section.

Fixes protocolbuffers/protobuf#28830

## Test plan
- [x] Confirmed the surrounding examples already use `release_nested_message` / `unsafe_arena_release_nested_message`
- [ ] Docs preview renders the corrected code block